### PR TITLE
Add auto registry for service end points

### DIFF
--- a/qbit/boon/src/main/java/io/advantageous/qbit/boon/BoonQBitFactory.java
+++ b/qbit/boon/src/main/java/io/advantageous/qbit/boon/BoonQBitFactory.java
@@ -243,10 +243,11 @@ public class BoonQBitFactory implements Factory {
                                                      final String endpointName,
                                                      final ServiceDiscovery serviceDiscovery,
                                                      final int port,
-                                                     final int ttlSeconds) {
+                                                     final int ttlSeconds,
+                                                     final HealthServiceAsync healthServiceAsync) {
         return new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle, jsonMapper,
                 timeOutInSeconds, numberOfOutstandingRequests, batchSize, flushInterval, systemManager,
-                endpointName, serviceDiscovery, port, ttlSeconds);
+                endpointName, serviceDiscovery, port, ttlSeconds, healthServiceAsync);
     }
 
 

--- a/qbit/boon/src/main/java/io/advantageous/qbit/boon/BoonQBitFactory.java
+++ b/qbit/boon/src/main/java/io/advantageous/qbit/boon/BoonQBitFactory.java
@@ -44,6 +44,7 @@ import io.advantageous.qbit.sender.SenderEndPoint;
 import io.advantageous.qbit.server.ServiceEndpointServer;
 import io.advantageous.qbit.server.ServiceEndpointServerImpl;
 import io.advantageous.qbit.service.*;
+import io.advantageous.qbit.service.discovery.ServiceDiscovery;
 import io.advantageous.qbit.service.health.HealthServiceAsync;
 import io.advantageous.qbit.service.impl.BoonServiceMethodCallHandler;
 import io.advantageous.qbit.service.impl.CallbackManager;
@@ -238,8 +239,14 @@ public class BoonQBitFactory implements Factory {
                                                      final ProtocolParser protocolParser, final ServiceBundle serviceBundle,
                                                      final JsonMapper jsonMapper, final int timeOutInSeconds,
                                                      final int numberOfOutstandingRequests, final int batchSize,
-                                                     final int flushInterval, final QBitSystemManager systemManager) {
-        return new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle, jsonMapper, timeOutInSeconds, numberOfOutstandingRequests, batchSize, flushInterval, systemManager);
+                                                     final int flushInterval, final QBitSystemManager systemManager,
+                                                     final String endpointName,
+                                                     final ServiceDiscovery serviceDiscovery,
+                                                     final int port,
+                                                     final int ttlSeconds) {
+        return new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle, jsonMapper,
+                timeOutInSeconds, numberOfOutstandingRequests, batchSize, flushInterval, systemManager,
+                endpointName, serviceDiscovery, port, ttlSeconds);
     }
 
 

--- a/qbit/boon/src/main/java/io/advantageous/qbit/server/ServiceEndpointServerImpl.java
+++ b/qbit/boon/src/main/java/io/advantageous/qbit/server/ServiceEndpointServerImpl.java
@@ -29,6 +29,7 @@ import io.advantageous.qbit.message.Response;
 import io.advantageous.qbit.queue.ReceiveQueueListener;
 import io.advantageous.qbit.reactive.Callback;
 import io.advantageous.qbit.service.ServiceBundle;
+import io.advantageous.qbit.service.ServiceProxyUtils;
 import io.advantageous.qbit.service.ServiceQueue;
 import io.advantageous.qbit.service.Stoppable;
 import io.advantageous.qbit.service.discovery.EndpointDefinition;
@@ -203,9 +204,9 @@ public class ServiceEndpointServerImpl implements ServiceEndpointServer {
                     serviceDiscovery.checkIn(endpoint.getId(), HealthStatus.FAIL);
                 }
             }
-            
-            healthServiceAsync.ok(ok::set);
 
+            healthServiceAsync.ok(ok::set);
+            ServiceProxyUtils.flushServiceProxy(healthServiceAsync);
         });
     }
     public void stop() {

--- a/qbit/boon/src/test/java/io/advantageous/qbit/server/ServerTest.java
+++ b/qbit/boon/src/test/java/io/advantageous/qbit/server/ServerTest.java
@@ -58,7 +58,7 @@ public class ServerTest extends TimedTesting {
         JsonMapper mapper = new BoonJsonMapper();
 
 
-        ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder, parser, serviceBundle, mapper, 30, 100, 30, 10, null);
+        ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder, parser, serviceBundle, mapper, 30, 100, 30, 10, null, null, null, 8080, 0);
 
         server.initServices(Sets.set(new TodoService()));
 
@@ -126,7 +126,9 @@ public class ServerTest extends TimedTesting {
         JsonMapper mapper = new BoonJsonMapper();
 
 
-        ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder, QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30, 10, null);
+        ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder,
+                QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30, 10, null,
+                null, null, 8080, 0);
 
         server.initServices(Sets.set(new TodoService()));
 
@@ -176,7 +178,9 @@ public class ServerTest extends TimedTesting {
         JsonMapper mapper = new BoonJsonMapper();
 
 
-        ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder, QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30, 10, null);
+        ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(
+                httpServer, encoder, QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30, 10,
+                null, null, null, 8080, 0);
 
         server.initServices(new TodoService());
 

--- a/qbit/boon/src/test/java/io/advantageous/qbit/server/ServerTest.java
+++ b/qbit/boon/src/test/java/io/advantageous/qbit/server/ServerTest.java
@@ -58,7 +58,8 @@ public class ServerTest extends TimedTesting {
         JsonMapper mapper = new BoonJsonMapper();
 
 
-        ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder, parser, serviceBundle, mapper, 30, 100, 30, 10, null, null, null, 8080, 0);
+        ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder,
+                parser, serviceBundle, mapper, 30, 100, 30, 10, null, null, null, 8080, 0, null);
 
         server.initServices(Sets.set(new TodoService()));
 
@@ -127,8 +128,9 @@ public class ServerTest extends TimedTesting {
 
 
         ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder,
-                QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30, 10, null,
-                null, null, 8080, 0);
+                QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30,
+                10, null,
+                null, null, 8080, 0, null);
 
         server.initServices(Sets.set(new TodoService()));
 
@@ -180,7 +182,7 @@ public class ServerTest extends TimedTesting {
 
         ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(
                 httpServer, encoder, QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30, 10,
-                null, null, null, 8080, 0);
+                null, null, null, 8080, 0, null);
 
         server.initServices(new TodoService());
 

--- a/qbit/boon/src/test/java/io/advantageous/qbit/server/ServiceEndpointServerImplTest.java
+++ b/qbit/boon/src/test/java/io/advantageous/qbit/server/ServiceEndpointServerImplTest.java
@@ -82,7 +82,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
 
         httpServer = new HttpServerMock();
-        serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle, mapper, 1, 100, 30, 10, null, "", null, 8080, 0);
+        serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle, mapper, 1, 100, 30, 10, null, "", null, 8080, 0, null);
 
 
         callMeCounter = 0;
@@ -112,7 +112,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         httpServer = new HttpServerMock();
         serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle,
-                mapper, 1, 100, 30, 10, null, null, null, 8080, 0);
+                mapper, 1, 100, 30, 10, null, null, null, 8080, 0, null);
 
 
         callMeCounter = 0;
@@ -162,7 +162,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         httpServer = new HttpServerMock();
         serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle,
-                mapper, 1, 100, 30, 10, null, null, null, 8080, 0);
+                mapper, 1, 100, 30, 10, null, null, null, 8080, 0, null);
 
 
         callMeCounter = 0;

--- a/qbit/boon/src/test/java/io/advantageous/qbit/server/ServiceEndpointServerImplTest.java
+++ b/qbit/boon/src/test/java/io/advantageous/qbit/server/ServiceEndpointServerImplTest.java
@@ -82,7 +82,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
 
         httpServer = new HttpServerMock();
-        serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle, mapper, 1, 100, 30, 10, null);
+        serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle, mapper, 1, 100, 30, 10, null, "", null, 8080, 0);
 
 
         callMeCounter = 0;
@@ -112,7 +112,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         httpServer = new HttpServerMock();
         serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle,
-                mapper, 1, 100, 30, 10, null);
+                mapper, 1, 100, 30, 10, null, null, null, 8080, 0);
 
 
         callMeCounter = 0;
@@ -162,7 +162,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         httpServer = new HttpServerMock();
         serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle,
-                mapper, 1, 100, 30, 10, null);
+                mapper, 1, 100, 30, 10, null, null, null, 8080, 0);
 
 
         callMeCounter = 0;

--- a/qbit/boon/src/test/java/io/advantageous/qbit/service/ServiceQueueErrorHandlingTest.java
+++ b/qbit/boon/src/test/java/io/advantageous/qbit/service/ServiceQueueErrorHandlingTest.java
@@ -26,6 +26,7 @@ public class ServiceQueueErrorHandlingTest {
 
     }
 
+    //Seems to work locally. 
     @Test
     public void test() throws InterruptedException {
 

--- a/qbit/boon/src/test/java/io/advantageous/qbit/service/ServiceQueueErrorHandlingTest.java
+++ b/qbit/boon/src/test/java/io/advantageous/qbit/service/ServiceQueueErrorHandlingTest.java
@@ -26,7 +26,7 @@ public class ServiceQueueErrorHandlingTest {
 
     }
 
-    //Seems to work locally. 
+    //Seems to work locally.
     @Test
     public void test() throws InterruptedException {
 
@@ -61,6 +61,8 @@ public class ServiceQueueErrorHandlingTest {
         });
 
         Sys.sleep(100);
+
+        countDownLatch2.await();
 
 
         assertEquals(2, count.get());

--- a/qbit/build.gradle
+++ b/qbit/build.gradle
@@ -257,6 +257,7 @@ project('cluster:admin') {
     test.onlyIf { Boolean.getBoolean('integration.tests') }
     dependencies {
         compile project(':qbit:boon')
+        compile project(':qbit:cluster:consul-client')
         compile project(':qbit:core')
         testCompile project(':qbit:cluster:consul-client')
         testCompile project(':qbit:test-support')

--- a/qbit/cluster/consul-client/src/main/java/io/advantageous/consul/discovery/ConsulServiceDiscoveryBuilder.java
+++ b/qbit/cluster/consul-client/src/main/java/io/advantageous/consul/discovery/ConsulServiceDiscoveryBuilder.java
@@ -27,7 +27,7 @@ public class ConsulServiceDiscoveryBuilder {
 
     private String consulHost = "localhost";
     private int consulPort = 8500;
-    private String datacenter;
+    private String datacenter = "dc1";
     private String tag;
     private int longPollTimeSeconds = 5;
     private PeriodicScheduler periodicScheduler;

--- a/qbit/cluster/consul-client/src/main/java/io/advantageous/consul/discovery/spi/ConsulServiceDiscoveryProvider.java
+++ b/qbit/cluster/consul-client/src/main/java/io/advantageous/consul/discovery/spi/ConsulServiceDiscoveryProvider.java
@@ -41,9 +41,6 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
     private final boolean debug = GlobalConstants.DEBUG || logger.isDebugEnabled();
     private final boolean trace = logger.isTraceEnabled();
     private final AtomicInteger lastIndex = new AtomicInteger();
-    /* Used to manage consul retry logic. */
-    private final AtomicInteger consulRetryCount = new AtomicInteger();
-    private final AtomicLong lastResetTimestamp = new AtomicLong(Timer.clockTime());
 
     private final Map<String,EndpointDefinition> registrations = new ConcurrentHashMap<>();
 

--- a/qbit/cluster/eventbus-replicator/src/main/java/io/advantageous/qbit/eventbus/EventBusCluster.java
+++ b/qbit/cluster/eventbus-replicator/src/main/java/io/advantageous/qbit/eventbus/EventBusCluster.java
@@ -1,8 +1,6 @@
 package io.advantageous.qbit.eventbus;
 
 import io.advantageous.boon.core.Str;
-import io.advantageous.boon.core.Sys;
-import io.advantageous.consul.domain.ServiceHealth;
 import io.advantageous.qbit.GlobalConstants;
 import io.advantageous.qbit.QBit;
 import io.advantageous.qbit.client.Client;
@@ -20,20 +18,17 @@ import io.advantageous.qbit.service.discovery.EndpointDefinition;
 import io.advantageous.qbit.service.discovery.ServiceDiscovery;
 import io.advantageous.qbit.service.discovery.ServicePool;
 import io.advantageous.qbit.service.discovery.ServicePoolListener;
-import io.advantageous.qbit.util.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 import static io.advantageous.qbit.eventbus.EventBusRemoteReplicatorBuilder.eventBusRemoteReplicatorBuilder;
 import static io.advantageous.qbit.eventbus.EventBusReplicationClientBuilder.eventBusReplicationClientBuilder;
@@ -96,6 +91,8 @@ public class EventBusCluster implements Startable, Stoppable {
 
         endpointDefinition = serviceDiscovery.registerWithTTL(eventBusName, replicationPortLocal,
                 (int) replicationServerCheckInTimeUnit.toSeconds(replicationServerCheckInInterval));
+
+        serviceDiscovery.checkInOk(endpointDefinition.getId());
     }
 
     private String getHost(String replicationHostLocal) {
@@ -188,7 +185,7 @@ public class EventBusCluster implements Startable, Stoppable {
     private void healthyNodeMonitor() {
 
 
-        logger.info("EventBusCluster::healthyNodeMonitor " + eventConnectorHub.size());
+        if (debug) logger.debug("EventBusCluster::healthyNodeMonitor " + eventConnectorHub.size());
         final List<EndpointDefinition> endpointDefinitions = serviceDiscovery.loadServices(eventBusName);
         final List<EndpointDefinition> removeNodes = new ArrayList<>();
 
@@ -215,7 +212,7 @@ public class EventBusCluster implements Startable, Stoppable {
 
                     if (replicationHostLocal.equals(endpointDefinition.getHost()) &&
                             replicationPortLocal == endpointDefinition.getPort()) {
-                        logger.info("EventBusCluster:: Add event for self " + eventBusName + " " + endpointDefinition);
+                        if (debug) logger.debug("EventBusCluster:: Add event for self " + eventBusName + " " + endpointDefinition);
                     } else {
                         change.set(true);
                         addEventConnector(endpointDefinition.getHost(), endpointDefinition.getPort());
@@ -230,7 +227,7 @@ public class EventBusCluster implements Startable, Stoppable {
 
                     if (replicationHostLocal.equals(endpointDefinition.getHost()) &&
                             replicationPortLocal == endpointDefinition.getPort()) {
-                        logger.info("EventBusCluster:: Remove event for self " + eventBusName + " " + endpointDefinition);
+                        if (debug) logger.debug("EventBusCluster:: Remove event for self " + eventBusName + " " + endpointDefinition);
                     } else {
                         change.set(true);
                         removeNodes.add(endpointDefinition);

--- a/qbit/cluster/eventbus-replicator/src/main/java/io/advantageous/qbit/eventbus/EventBusClusterBuilder.java
+++ b/qbit/cluster/eventbus-replicator/src/main/java/io/advantageous/qbit/eventbus/EventBusClusterBuilder.java
@@ -1,5 +1,6 @@
 package io.advantageous.qbit.eventbus;
 
+import io.advantageous.consul.discovery.ConsulServiceDiscoveryBuilder;
 import io.advantageous.qbit.GlobalConstants;
 import io.advantageous.qbit.concurrent.PeriodicScheduler;
 import io.advantageous.qbit.events.EventManager;
@@ -19,37 +20,27 @@ public class EventBusClusterBuilder {
     private PeriodicScheduler periodicScheduler = null;
     private int peerCheckTimeInterval = 7;
     private TimeUnit peerCheckTimeUnit = TimeUnit.SECONDS;
-    private String consulHost = null;
-    private int consulPort = 8500;
-    private String datacenter = null;
-    private String tag = null;
     private int longPollTimeSeconds = 5;
-    private String localEventBusId;
     private int replicationPortLocal = 9090;
     private String replicationHostLocal = null;
     private EventManager eventManager = null;
-    private int replicationServerCheckInIntervalInSeconds = 5;
+    private int replicationServerCheckInInterval = 5;
+    private TimeUnit replicationServerCheckInTimeUnit = TimeUnit.SECONDS;
 
-    public static EventBusClusterBuilder eventBusRingBuilder() {
+    private ServiceDiscovery serviceDiscovery;
+
+
+    public static EventBusClusterBuilder eventBusClusterBuilder() {
         return new EventBusClusterBuilder();
     }
 
     public EventBusCluster build() {
 
-        if (consulHost == null) {
-            consulHost = "localhost";
-        }
+        return new EventBusCluster(getEventManager(), getEventBusName(), getEventConnectorHub(), getPeriodicScheduler(),
+                getPeerCheckTimeInterval(), getPeerCheckTimeUnit(), getReplicationServerCheckInInterval(),
+                getReplicationServerCheckInTimeUnit(), getServiceDiscovery(), getReplicationPortLocal(),
+                getReplicationHostLocal() );
 
-        if (localEventBusId == null) {
-            localEventBusId = eventBusName + "-" + ServiceDiscovery.uniqueString(replicationPortLocal);
-        }
-
-        return new EventBusCluster(getEventManager(), getEventBusName(), getLocalEventBusId(),
-                getEventConnectorHub(), getPeriodicScheduler(),
-                getPeerCheckTimeInterval(), getPeerCheckTimeUnit(), getConsulHost(),
-                getConsulPort(), getLongPollTimeSeconds(), getReplicationPortLocal(),
-                getReplicationHostLocal(), getDatacenter(), getTag(),
-                getReplicationServerCheckInIntervalInSeconds());
     }
 
     public String getEventBusName() {
@@ -97,41 +88,6 @@ public class EventBusClusterBuilder {
         return this;
     }
 
-    public String getConsulHost() {
-        return consulHost;
-    }
-
-    public EventBusClusterBuilder setConsulHost(String consulHost) {
-        this.consulHost = consulHost;
-        return this;
-    }
-
-    public int getConsulPort() {
-        return consulPort;
-    }
-
-    public EventBusClusterBuilder setConsulPort(int consulPort) {
-        this.consulPort = consulPort;
-        return this;
-    }
-
-    public String getDatacenter() {
-        return datacenter;
-    }
-
-    public EventBusClusterBuilder setDatacenter(String datacenter) {
-        this.datacenter = datacenter;
-        return this;
-    }
-
-    public String getTag() {
-        return tag;
-    }
-
-    public EventBusClusterBuilder setTag(String tag) {
-        this.tag = tag;
-        return this;
-    }
 
     public int getLongPollTimeSeconds() {
         return longPollTimeSeconds;
@@ -142,14 +98,6 @@ public class EventBusClusterBuilder {
         return this;
     }
 
-    public String getLocalEventBusId() {
-        return localEventBusId;
-    }
-
-    public EventBusClusterBuilder setLocalEventBusId(String localEventBusId) {
-        this.localEventBusId = localEventBusId;
-        return this;
-    }
 
     public int getReplicationPortLocal() {
         return replicationPortLocal;
@@ -178,12 +126,34 @@ public class EventBusClusterBuilder {
         return this;
     }
 
-    public int getReplicationServerCheckInIntervalInSeconds() {
-        return replicationServerCheckInIntervalInSeconds;
+    public int getReplicationServerCheckInInterval() {
+        return replicationServerCheckInInterval;
     }
 
-    public EventBusClusterBuilder setReplicationServerCheckInIntervalInSeconds(int replicationServerCheckInIntervalInSeconds) {
-        this.replicationServerCheckInIntervalInSeconds = replicationServerCheckInIntervalInSeconds;
+    public EventBusClusterBuilder setReplicationServerCheckInInterval(int replicationServerCheckInInterval) {
+        this.replicationServerCheckInInterval = replicationServerCheckInInterval;
+        return this;
+    }
+
+    public TimeUnit getReplicationServerCheckInTimeUnit() {
+        return replicationServerCheckInTimeUnit;
+    }
+
+    public EventBusClusterBuilder setReplicationServerCheckInTimeUnit(TimeUnit replicationServerCheckInTimeUnit) {
+        this.replicationServerCheckInTimeUnit = replicationServerCheckInTimeUnit;
+        return this;
+    }
+
+    public ServiceDiscovery getServiceDiscovery() {
+        if (serviceDiscovery == null) {
+            serviceDiscovery = ConsulServiceDiscoveryBuilder.consulServiceDiscoveryBuilder().build();
+            serviceDiscovery.start();
+        }
+        return serviceDiscovery;
+    }
+
+    public EventBusClusterBuilder setServiceDiscovery(ServiceDiscovery serviceDiscovery) {
+        this.serviceDiscovery = serviceDiscovery;
         return this;
     }
 }

--- a/qbit/cluster/eventbus-replicator/src/test/java/io/advantageous/qbit/eventbus/EventBusRingBuilderTest.java
+++ b/qbit/cluster/eventbus-replicator/src/test/java/io/advantageous/qbit/eventbus/EventBusRingBuilderTest.java
@@ -7,7 +7,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static io.advantageous.boon.core.IO.puts;
-import static io.advantageous.qbit.eventbus.EventBusClusterBuilder.eventBusRingBuilder;
 import static io.advantageous.qbit.util.PortUtils.useOneOfThePortsInThisRange;
 
 public class EventBusRingBuilderTest {
@@ -29,8 +28,7 @@ public class EventBusRingBuilderTest {
     public void setup() {
 
         port = useOneOfThePortsInThisRange(9000, 9900);
-        EventBusClusterBuilder eventBusClusterBuilder = eventBusRingBuilder();
-        eventBusClusterBuilder.setConsulHost("localhost");
+        EventBusClusterBuilder eventBusClusterBuilder = EventBusClusterBuilder.eventBusClusterBuilder();
         eventBusClusterBuilder.setReplicationPortLocal(port);
 
         eventBusCluster = eventBusClusterBuilder.build();

--- a/qbit/cluster/eventbus-replicator/src/test/java/io/advantageous/qbit/eventbus/EventManagerReplicationIntegrationTest.java
+++ b/qbit/cluster/eventbus-replicator/src/test/java/io/advantageous/qbit/eventbus/EventManagerReplicationIntegrationTest.java
@@ -43,7 +43,7 @@ public class EventManagerReplicationIntegrationTest extends TimedTesting {
 
 
         /** Build B. */
-        EventManager eventManagerBImpl = eventManagerBuilderB.build();
+        EventManager eventManagerBImpl = eventManagerBuilderB.build("eventBusB");
 
 
         /** replicated to B. */
@@ -61,7 +61,7 @@ public class EventManagerReplicationIntegrationTest extends TimedTesting {
 
 
         /* Create A that connects to the replicator client. */
-        EventManager eventManagerAImpl = eventManagerBuilderA.setEventConnector(replicatorClient).build();
+        EventManager eventManagerAImpl = eventManagerBuilderA.setEventConnector(replicatorClient).build("eventBusA");
         serviceBundle.addServiceObject("eventManagerA", eventManagerAImpl);
         eventManagerA = serviceBundle.createLocalProxy(EventManager.class, "eventManagerA"); //wire A to Service Bundle
 

--- a/qbit/cluster/eventbus-replicator/src/test/java/io/advantageous/qbit/eventbus/EventManagerReplicationOverWebSocket.java
+++ b/qbit/cluster/eventbus-replicator/src/test/java/io/advantageous/qbit/eventbus/EventManagerReplicationOverWebSocket.java
@@ -55,20 +55,20 @@ public class EventManagerReplicationOverWebSocket extends TimedTesting {
         EventManagerBuilder eventManagerBuilderC = new EventManagerBuilder();
 
         /** Build A. */
-        EventManager eventManagerAImpl = eventManagerBuilderA.setEventConnector(replicatorHubA).build();
+        EventManager eventManagerAImpl = eventManagerBuilderA.setEventConnector(replicatorHubA).build("eventBusA");
         serviceBundleA = serviceBundleBuilder().build(); //build service bundle
         serviceBundleA.addServiceObject("eventManagerA", eventManagerAImpl);
         eventManagerA = serviceBundleA.createLocalProxy(EventManager.class, "eventManagerA"); //wire A to Service Bundle
 
 
         /** Build B. */
-        EventManager eventManagerBImpl = eventManagerBuilderB.setEventConnector(replicatorHubB).build();
+        EventManager eventManagerBImpl = eventManagerBuilderB.setEventConnector(replicatorHubB).build("eventBusB");
         serviceBundleB = serviceBundleBuilder().build(); //build service bundle
         serviceBundleB.addServiceObject("eventManagerB", eventManagerBImpl);
         eventManagerB = serviceBundleB.createLocalProxy(EventManager.class, "eventManagerB"); //wire B to Service Bundle
 
         /** Build C. */
-        EventManager eventManagerCImpl = eventManagerBuilderC.setEventConnector(replicatorHubC).build();
+        EventManager eventManagerCImpl = eventManagerBuilderC.setEventConnector(replicatorHubC).build("eventBusC");
         serviceBundleC = serviceBundleBuilder().build(); //build service bundle
         serviceBundleC.addServiceObject("eventManagerC", eventManagerCImpl);
         eventManagerC = serviceBundleC.createLocalProxy(EventManager.class, "eventManagerC"); //wire C to Service Bundle

--- a/qbit/core/src/main/java/io/advantageous/qbit/Factory.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/Factory.java
@@ -39,6 +39,7 @@ import io.advantageous.qbit.service.BeforeMethodCall;
 import io.advantageous.qbit.service.ServiceBundle;
 import io.advantageous.qbit.service.ServiceMethodHandler;
 import io.advantageous.qbit.service.ServiceQueue;
+import io.advantageous.qbit.service.discovery.ServiceDiscovery;
 import io.advantageous.qbit.service.health.HealthServiceAsync;
 import io.advantageous.qbit.service.impl.CallbackManager;
 import io.advantageous.qbit.service.stats.StatsCollector;
@@ -336,7 +337,11 @@ public interface Factory {
                                                       final int numberOfOutstandingRequests,
                                                       final int batchSize,
                                                       final int flushInterval,
-                                                      final QBitSystemManager systemManager
+                                                      final QBitSystemManager systemManager,
+                                                      final String endpointName,
+                                                      final ServiceDiscovery serviceDiscovery,
+                                                      final int port,
+                                                      final int ttlSeconds
     ) {
         throw new UnsupportedOperationException();
     }

--- a/qbit/core/src/main/java/io/advantageous/qbit/Factory.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/Factory.java
@@ -341,7 +341,8 @@ public interface Factory {
                                                       final String endpointName,
                                                       final ServiceDiscovery serviceDiscovery,
                                                       final int port,
-                                                      final int ttlSeconds
+                                                      final int ttlSeconds,
+                                                      final HealthServiceAsync healthServiceAsync
     ) {
         throw new UnsupportedOperationException();
     }

--- a/qbit/core/src/main/java/io/advantageous/qbit/events/EventManagerBuilder.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/events/EventManagerBuilder.java
@@ -109,12 +109,13 @@ public class EventManagerBuilder {
 
     public EventManager build(final String name) {
 
+
         if ( eventConnector == null) {
             return getFactory().createEventManager(name, getEventConnector(), getStatsCollector());
         } else {
 
             if (getEventConnectorPredicates().size() == 0) {
-                return getFactory().createEventManager(getName(), getEventConnector(), getStatsCollector());
+                return getFactory().createEventManager(name, getEventConnector(), getStatsCollector());
             } else {
 
                 Predicate<Event<Object>> mainPredicate = getEventConnectorPredicates().get(0);
@@ -122,7 +123,7 @@ public class EventManagerBuilder {
                 for (int index = 1; index < eventConnectorPredicates.size(); index++) {
                     mainPredicate = mainPredicate.and(eventConnectorPredicates.get(index));
                 }
-                return getFactory().createEventManager(getName(),
+                return getFactory().createEventManager(name,
                         new ConditionalEventConnector(mainPredicate, getEventConnector()), getStatsCollector());
             }
 

--- a/qbit/core/src/main/java/io/advantageous/qbit/server/EndpointServerBuilder.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/server/EndpointServerBuilder.java
@@ -610,7 +610,7 @@ public class EndpointServerBuilder {
                 getEncoder(), getParser(), serviceBundle, getJsonMapper(), this.getTimeoutSeconds(),
                 this.getNumberOfOutstandingRequests(), this.getRequestBatchSize(),
                 this.getFlushInterval(), this.getSystemManager(), getEndpointName(),
-                getServiceDiscovery(), getPort(), getTtlSeconds());
+                getServiceDiscovery(), getPort(), getTtlSeconds(), getHealthService());
 
 
         if (serviceEndpointServer != null && qBitSystemManager != null) {

--- a/qbit/core/src/main/java/io/advantageous/qbit/server/EndpointServerBuilder.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/server/EndpointServerBuilder.java
@@ -33,6 +33,7 @@ import io.advantageous.qbit.reactive.Callback;
 import io.advantageous.qbit.service.BeforeMethodCall;
 import io.advantageous.qbit.service.CallbackManagerBuilder;
 import io.advantageous.qbit.service.ServiceBundle;
+import io.advantageous.qbit.service.discovery.ServiceDiscovery;
 import io.advantageous.qbit.service.health.HealthServiceAsync;
 import io.advantageous.qbit.service.health.HealthServiceBuilder;
 import io.advantageous.qbit.service.impl.CallbackManager;
@@ -98,6 +99,36 @@ public class EndpointServerBuilder {
     private StatCollection statsCollection;
     private List<Object> services;
 
+    private String endpointName;
+    private ServiceDiscovery serviceDiscovery;
+    private int ttlSeconds;
+
+    public String getEndpointName() {
+        return endpointName;
+    }
+
+    public EndpointServerBuilder setEndpointName(String endpointName) {
+        this.endpointName = endpointName;
+        return this;
+    }
+
+    public ServiceDiscovery getServiceDiscovery() {
+        return serviceDiscovery;
+    }
+
+    public EndpointServerBuilder setServiceDiscovery(ServiceDiscovery serviceDiscovery) {
+        this.serviceDiscovery = serviceDiscovery;
+        return this;
+    }
+
+    public int getTtlSeconds() {
+        return ttlSeconds;
+    }
+
+    public EndpointServerBuilder setTtlSeconds(int ttlSeconds) {
+        this.ttlSeconds = ttlSeconds;
+        return this;
+    }
 
     public boolean isEnableHealthEndpoint() {
         return enableHealthEndpoint;
@@ -525,7 +556,8 @@ public class EndpointServerBuilder {
         final ServiceEndpointServer serviceEndpointServer = QBit.factory().createServiceServer(httpServer,
                 encoder, parser, serviceBundle, jsonMapper, this.getTimeoutSeconds(),
                 this.getNumberOfOutstandingRequests(), this.getRequestBatchSize(),
-                this.getFlushInterval(), this.getSystemManager());
+                this.getFlushInterval(), this.getSystemManager(), getEndpointName(),
+                getServiceDiscovery(), getPort(), getTtlSeconds());
 
 
         if (serviceEndpointServer != null && qBitSystemManager != null) {

--- a/qbit/core/src/main/java/io/advantageous/qbit/server/EndpointServerBuilder.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/server/EndpointServerBuilder.java
@@ -19,6 +19,7 @@
 package io.advantageous.qbit.server;
 
 import io.advantageous.boon.json.JsonFactory;
+import io.advantageous.qbit.Factory;
 import io.advantageous.qbit.QBit;
 import io.advantageous.qbit.config.PropertyResolver;
 import io.advantageous.qbit.http.HttpTransport;
@@ -102,6 +103,61 @@ public class EndpointServerBuilder {
     private String endpointName;
     private ServiceDiscovery serviceDiscovery;
     private int ttlSeconds;
+
+    private Factory factory;
+
+    private JsonMapper jsonMapper;
+    private ProtocolEncoder encoder;
+
+    public EndpointServerBuilder setParser(ProtocolParser parser) {
+        this.parser = parser;
+        return this;
+    }
+
+    private ProtocolParser parser;
+
+    public ProtocolParser getParser() {
+        if (parser==null) {
+            parser = getFactory().createProtocolParser();
+        }
+        return parser;
+    }
+
+    public Factory getFactory() {
+        if (factory == null) {
+            factory = QBit.factory();
+        }
+        return factory;
+    }
+
+    public void setFactory(Factory factory) {
+        this.factory = factory;
+    }
+
+    public JsonMapper getJsonMapper() {
+        if (jsonMapper == null) {
+
+            jsonMapper = getFactory().createJsonMapper();
+        }
+        return jsonMapper;
+    }
+
+    public EndpointServerBuilder setJsonMapper(JsonMapper jsonMapper) {
+        this.jsonMapper = jsonMapper;
+        return this;
+    }
+
+    public ProtocolEncoder getEncoder() {
+        if (encoder == null) {
+            encoder = getFactory().createEncoder();
+        }
+        return encoder;
+    }
+
+    public EndpointServerBuilder setEncoder(ProtocolEncoder encoder) {
+        this.encoder = encoder;
+        return this;
+    }
 
     public String getEndpointName() {
         return endpointName;
@@ -528,8 +584,6 @@ public class EndpointServerBuilder {
 
 
 
-        final JsonMapper jsonMapper = QBit.factory().createJsonMapper();
-        final ProtocolEncoder encoder = QBit.factory().createEncoder();
 
 
         final ServiceBundle serviceBundle;
@@ -539,7 +593,7 @@ public class EndpointServerBuilder {
                 getRequestQueueBuilder(),
                 getResponseQueueBuilder(),
                 getWebResponseQueueBuilder(),
-                QBit.factory(),
+                getFactory(),
                 eachServiceInItsOwnThread, this.getBeforeMethodCall(),
                 this.getBeforeMethodCallAfterTransform(),
                 this.getArgTransformer(), true,
@@ -550,11 +604,10 @@ public class EndpointServerBuilder {
                 getCheckTimingEveryXCalls(),
                 getCallbackManager());
 
-        final ProtocolParser parser = QBit.factory().createProtocolParser();
 
 
-        final ServiceEndpointServer serviceEndpointServer = QBit.factory().createServiceServer(httpServer,
-                encoder, parser, serviceBundle, jsonMapper, this.getTimeoutSeconds(),
+        final ServiceEndpointServer serviceEndpointServer = getFactory().createServiceServer(httpServer,
+                getEncoder(), getParser(), serviceBundle, getJsonMapper(), this.getTimeoutSeconds(),
                 this.getNumberOfOutstandingRequests(), this.getRequestBatchSize(),
                 this.getFlushInterval(), this.getSystemManager(), getEndpointName(),
                 getServiceDiscovery(), getPort(), getTtlSeconds());


### PR DESCRIPTION
This makes endpoint builders auto register with service discovery. 

```java
    final ManagedServiceBuilder managedServiceBuilder =
             ManagedServiceBuilder.managedServiceBuilder();

    managedServiceBuilder.enableConsulServiceDiscovery("dc1");
...
        final ServiceEndpointServer serviceEndpointServer = managedServiceBuilder.getEndpointServerBuilder()
                .setUri("/").setEndpointName("api-services").setTtlSeconds(10)
                .build();
```

Notice the new methods on EndpointServerBuilder.

```java
  .setEndpointName(...) 
  .setTtlSeconds(...)
  .setServiceDiscovery(...)
```


The ManagedServiceBuilder is a nice class to manage system shutdown, shared stats like statsD, etc.
It is for non-spring users.

It has the following helper methods to enable consul service discovery.

```java

    public void enableConsulServiceDiscovery(String dataCenter) {
        final ConsulServiceDiscoveryBuilder consulServiceDiscoveryBuilder = ConsulServiceDiscoveryBuilder.consulServiceDiscoveryBuilder();
        consulServiceDiscoveryBuilder.setDatacenter(dataCenter);
        serviceDiscoverySupplier = () -> consulServiceDiscoveryBuilder.build();
    }

    public void enableConsulServiceDiscovery(String dataCenter, String host) {
        final ConsulServiceDiscoveryBuilder consulServiceDiscoveryBuilder = ConsulServiceDiscoveryBuilder.consulServiceDiscoveryBuilder();
        consulServiceDiscoveryBuilder.setDatacenter(dataCenter);
        consulServiceDiscoveryBuilder.setConsulHost(host);
        serviceDiscoverySupplier = () -> consulServiceDiscoveryBuilder.build();
    }


    public void enableConsulServiceDiscovery(String dataCenter, String host, int port) {
        final ConsulServiceDiscoveryBuilder consulServiceDiscoveryBuilder = ConsulServiceDiscoveryBuilder.consulServiceDiscoveryBuilder();
        consulServiceDiscoveryBuilder.setDatacenter(dataCenter);
        consulServiceDiscoveryBuilder.setConsulHost(host);
        consulServiceDiscoveryBuilder.setConsulPort(port);
        serviceDiscoverySupplier = () -> consulServiceDiscoveryBuilder.build();
    }

```

It is similar to the Spring support we are working on but for non-Spring users. 
It wires in the write pieces of the puzzle.