### PR TITLE
Misplaced path variable always causes errors.

### DIFF
--- a/qbit/core/src/main/java/io/advantageous/qbit/meta/transformer/StandardRequestTransformer.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/meta/transformer/StandardRequestTransformer.java
@@ -33,7 +33,6 @@ import io.advantageous.qbit.meta.params.*;
 import io.advantageous.qbit.meta.provider.StandardMetaDataProvider;
 import io.advantageous.qbit.reactive.Callback;
 import io.advantageous.qbit.service.CaptureRequestInterceptor;
-import io.advantageous.qbit.service.RequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -187,20 +186,22 @@ public class StandardRequestTransformer implements RequestTransformer {
 
                     final String[] pathSplit = Str.split(request.address(), '/');
 
+                    value = null;
                     if (positionalParam.getIndexIntoURI() >= pathSplit.length) {
                         if (positionalParam.isRequired()) {
                             errorsList.add(sputs("Unable to find required path param",
                                     positionalParam.getIndexIntoURI()));
                             break loop;
                         }
+                    } else {
+                        value = pathSplit[positionalParam.getIndexIntoURI()];
+                        if (positionalParam.isRequired() && Str.isEmpty(value)) {
+                            errorsList.add(sputs("Unable to find required path param",
+                                    positionalParam.getIndexIntoURI()));
+                            break loop;
+                        }
                     }
 
-                    value = pathSplit[positionalParam.getIndexIntoURI()];
-                    if (positionalParam.isRequired() && Str.isEmpty(value)) {
-                        errorsList.add(sputs("Unable to find required path param",
-                                positionalParam.getIndexIntoURI()));
-                        break loop;
-                    }
                     if (Str.isEmpty(value)) {
                         value = positionalParam.getDefaultValue();
                     }

--- a/qbit/core/src/test/java/io/advantageous/qbit/transformer/SampleService.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/transformer/SampleService.java
@@ -2,6 +2,7 @@ package io.advantageous.qbit.transformer;
 
 
 import io.advantageous.qbit.annotation.*;
+import io.advantageous.qbit.reactive.Callback;
 
 import static io.advantageous.boon.core.Str.sputs;
 
@@ -52,5 +53,8 @@ public class SampleService {
         return sputs(arg1, arg2, employee);
     }
 
-
+    @RequestMapping("/simpleBadConfig1/{0}/")
+    public void simpleBadConfig(Callback<String> callback, @PathVariable(defaultValue = "missing") final String arg1) {
+        callback.accept("simple3");
+    }
 }

--- a/qbit/core/src/test/java/io/advantageous/qbit/transformer/StandardRequestTransformerTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/transformer/StandardRequestTransformerTest.java
@@ -17,7 +17,9 @@ import java.util.Optional;
 import static io.advantageous.boon.core.IO.puts;
 import static io.advantageous.boon.core.Maps.safeMap;
 import static io.advantageous.boon.json.JsonFactory.toJson;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public class StandardRequestTransformerTest {
@@ -80,6 +82,37 @@ public class StandardRequestTransformerTest {
         @SuppressWarnings("unchecked") List<Object> args = (List<Object>) methodCall.body();
 
         assertEquals("1", args.get(0));
+    }
+
+    @Test
+    public void testTransformBadPathParamIndex() throws Exception {
+
+        /*
+
+                /services
+
+
+        @RequestMapping("/sample/service")
+        public class SampleService {
+
+
+            @RequestMapping("/simpleBadConfig1/{0}")
+            public void simpleBadConfig1(Callback<String> callback, @PathVariable(defaultValue = "missing" final String arg1) {
+                callback.accept("simple3");
+            }
+         */
+
+        HttpRequestBuilder requestBuilder = new HttpRequestBuilder();
+        requestBuilder.setUri("/services/sample/service/simpleBadConfig1/someValue");
+        final HttpRequest request = requestBuilder.build();
+
+        List<String> errorsList = new ArrayList<>();
+
+        final MethodCall<Object> methodCall = standardRequestTransformer.transform(request, errorsList);
+
+        @SuppressWarnings("unchecked") List<Object> args = (List<Object>) methodCall.body();
+
+        assertEquals("missing", args.get(0));
     }
 
     @Test


### PR DESCRIPTION
The check in place for path variables that are not required does not
prevent from trying to get them by index and often running into a index
out-of-bound exception. The commit fixes it.