### PR TITLE
Fix ArrayIndexOutOfBound for rootURI=/

### DIFF
--- a/qbit/core/src/main/java/io/advantageous/qbit/meta/provider/StandardMetaDataProvider.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/meta/provider/StandardMetaDataProvider.java
@@ -146,7 +146,7 @@ public class StandardMetaDataProvider implements MetaDataProvider {
                 return null;
             }
 
-            final String requestURI = StringScanner.substringAfter(path, rootURI);
+            final String requestURI = Str.isEmpty(rootURI) ? path : StringScanner.substringAfter(path, rootURI);
 
             int count = Str.split(requestURI, '/').length -1;
             NavigableMap<Integer, RequestMetaData> uriParamMap = uriParamNumMapEntry.getValue();

--- a/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/VertxRESTIntegrationTest.java
+++ b/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/VertxRESTIntegrationTest.java
@@ -1,6 +1,7 @@
 package io.advantageous.qbit.vertx;
 
 import io.advantageous.boon.core.Sys;
+import io.advantageous.qbit.annotation.PathVariable;
 import io.advantageous.qbit.annotation.RequestMapping;
 import io.advantageous.qbit.annotation.RequestMethod;
 import io.advantageous.qbit.http.client.HttpClient;
@@ -38,6 +39,11 @@ public class VertxRESTIntegrationTest {
         @RequestMapping(value = "/world", method = RequestMethod.POST)
         public String hello(String body) {
             return body;
+        }
+        
+        @RequestMapping(value = "/sayHi/{0}", method = RequestMethod.GET)
+        public String sayHi(@PathVariable String to) {
+            return to;
         }
     }
 
@@ -143,6 +149,9 @@ public class VertxRESTIntegrationTest {
         assertEquals(200, response2.code());
         assertEquals("\"hi\"", response2.body());
 
+        final HttpTextResponse response3 = client.get("/hello/sayHi/me");
+        assertEquals(200, response3.code());
+        assertEquals("\"me\"", response3.body());
     }
 
 


### PR DESCRIPTION
If rootURI is set to "/" it gets turned into "" in
io.advantageous.qbit.service.impl.ServiceBundleImpl#ServiceBundleImpl

Then if we match "" and say "/hello/world" it causes

```
Dec 03, 2015 11:16:40 PM io.vertx.ext.web.impl.RoutingContextImplBase
SEVERE: Unexpected exception in route
java.lang.ArrayIndexOutOfBoundsException: 0
    at
io.advantageous.boon.primitive.CharScanner.findChars(CharScanner.java:1673)
    at
io.advantageous.boon.primitive.CharScanner.findChars(CharScanner.java:1630)
    at
io.advantageous.boon.core.StringScanner.findString(StringScanner.java:303)
    at
io.advantageous.boon.core.StringScanner.substringAfter(StringScanner.java:293)
    at
io.advantageous.qbit.meta.provider.StandardMetaDataProvider.doGet(StandardMetaDataProvider.java:149)
```

The fix is to have a special case for rootURI is empty. Alternatively
StringScanner.substringAfter(path, rootURI) may be fixed to deal with
empty case differently.