### PR TITLE
Bag for request specific data and its support

### DIFF
--- a/qbit/core/src/main/java/io/advantageous/qbit/annotation/DataParam.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/annotation/DataParam.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2015. Rick Hightower, Geoff Chandler
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  		http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * QBit - The Microservice lib for Java : JSON, WebSocket, REST. Be The Web!
+ */
+
+package io.advantageous.qbit.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines a data parameter for mapping service methods to HTTP like calls.
+ *
+ * @author Boris Byk
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = {ElementType.PARAMETER})
+public @interface DataParam {
+
+    /** Name of the data param. */
+    String value();
+
+    boolean required() default false;
+
+    /** Default value.
+     * The default value is set to AnnotationConstants.NOT_SET which is used
+     * to indicate a default value was not set.
+     * @return default value
+     */
+    String defaultValue() default AnnotationConstants.NOT_SET;
+
+
+    /**
+     * Used to document endpoint
+     * @return description
+     */
+    String description() default "no description";
+
+
+}

--- a/qbit/core/src/main/java/io/advantageous/qbit/http/request/HttpRequest.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/http/request/HttpRequest.java
@@ -22,6 +22,7 @@ import io.advantageous.qbit.message.Request;
 import io.advantageous.qbit.util.MultiMap;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
+import java.util.Map;
 
 
 /**
@@ -33,6 +34,7 @@ import java.util.function.Supplier;
  */
 public class HttpRequest implements Request<Object> {
 
+    private final Map<String, Object> data;
     private final String uri;
     private final String remoteAddress;
     private final MultiMap<String, String> params;
@@ -51,6 +53,7 @@ public class HttpRequest implements Request<Object> {
     public HttpRequest(final long id,
                        final String uri,
                        final String method,
+                       final Map<String, Object> data,
                        final MultiMap<String, String> params,
                        final MultiMap<String, String> headers,
                        final Supplier<Object> bodySupplier,
@@ -60,6 +63,7 @@ public class HttpRequest implements Request<Object> {
                        final Supplier<MultiMap<String, String>> formParamsSupplier,
                        final long timestamp) {
 
+        this.data = data;
         this.uri = uri;
         this.messageId = id;
         this.params = params;
@@ -183,6 +187,10 @@ public class HttpRequest implements Request<Object> {
 
     public String getMethod() {
         return method;
+    }
+
+    public Map<String, Object> data() {
+        return data;
     }
 
     public String getUri() {

--- a/qbit/core/src/main/java/io/advantageous/qbit/http/request/HttpRequestBuilder.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/http/request/HttpRequestBuilder.java
@@ -63,6 +63,7 @@ public class HttpRequestBuilder {
 
     private HttpResponseReceiver receiver = (code, mimeType, body1) -> {
     };
+    private Map<String, Object> data;
 
     public Supplier<MultiMap<String, String>> getFormParamsSupplier() {
         return formParamsSupplier;
@@ -233,7 +234,7 @@ public class HttpRequestBuilder {
         if (contentType != null) {
             this.addHeader("Content-Type", contentType);
         }
-        return new HttpRequest(this.getId(), newURI, this.getMethod(), this.getParams(),
+        return new HttpRequest(this.getId(), newURI, this.getMethod(), this.getData(), this.getParams(),
                 this.getHeaders(),
                 this.getBodySupplier(),
                 this.getRemoteAddress(), this.getContentType(), httpResponse,
@@ -260,7 +261,7 @@ public class HttpRequestBuilder {
         if (contentType != null) {
             this.addHeader("Content-Type", contentType);
         }
-        final HttpRequest request = new HttpRequest(this.getId(), newURI, this.getMethod(), this.getParams(),
+        final HttpRequest request = new HttpRequest(this.getId(), newURI, this.getMethod(), this.getData(), this.getParams(),
                 this.getHeaders(),
                 this.getBodySupplier(),
                 this.getRemoteAddress(), this.getContentType(), httpResponse,
@@ -437,7 +438,6 @@ public class HttpRequestBuilder {
         setBodyBytes(paramString.getBytes(StandardCharsets.UTF_8));
 
 
-
         return this;
     }
 
@@ -489,13 +489,12 @@ public class HttpRequestBuilder {
         }
 
 
-
         return this;
     }
 
     /**
-     *
      * Copies the request's body, headers, uri, request params, content type, etc into this builder
+     *
      * @param request request to copy
      * @return this
      */
@@ -506,7 +505,7 @@ public class HttpRequestBuilder {
 
         this.setMethod(request.getMethod());
 
-        if (request.getHeaders().size()>0) {
+        if (request.getHeaders().size() > 0) {
             if (this.headers == null) {
                 this.setHeaders(new MultiMapImpl<>());
             }
@@ -516,10 +515,10 @@ public class HttpRequestBuilder {
             });
         }
 
-        if (request.getParams().size()>0) {
+        if (request.getParams().size() > 0) {
 
 
-            if (this.params==null) {
+            if (this.params == null) {
                 this.setParams(new MultiMapImpl<>());
             }
 
@@ -536,6 +535,15 @@ public class HttpRequestBuilder {
 
 
         return this;
+    }
+
+    public HttpRequestBuilder setData(Map<String, Object> data) {
+        this.data = data;
+        return this;
+    }
+
+    public Map<String, Object> getData() {
+        return data;
     }
 
     private static class RequestIdGenerator {

--- a/qbit/core/src/main/java/io/advantageous/qbit/meta/builder/RequestMetaBuilder.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/meta/builder/RequestMetaBuilder.java
@@ -238,6 +238,9 @@ public class RequestMetaBuilder {
             case "headerParam":
                 param = new HeaderParam(required, paramName, defaultValue, description);
                 break;
+            case "dataParam":
+                param = new DataParam(required, paramName, defaultValue, description);
+                break;
             case "pathVariable":
 
                 if (!path.contains("{")) {

--- a/qbit/core/src/main/java/io/advantageous/qbit/meta/params/DataParam.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/meta/params/DataParam.java
@@ -19,14 +19,13 @@ package io.advantageous.qbit.meta.params;
 
 
 /**
- * Types of parameters
+ * Holds meta data about a body where a header represents a single argument to a method.
  */
-public enum ParamType {
-    BODY,
-    REQUEST,
-    HEADER,
-    DATA,
-    PATH_BY_NAME,
-    PATH_BY_POSITION,
-    BODY_BY_POSITION,
+public class DataParam extends NamedParam {
+
+
+    public DataParam(final boolean required, final String name, Object defaultValue,
+                     final String description) {
+        super(required, name, defaultValue, ParamType.DATA, description);
+    }
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/meta/transformer/StandardRequestTransformer.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/meta/transformer/StandardRequestTransformer.java
@@ -159,6 +159,17 @@ public class StandardRequestTransformer implements RequestTransformer {
                     }
                     value = value !=null ? decodeURLEncoding(value.toString()) : value;
                     break;
+                case DATA:
+                    namedParam = ((NamedParam) parameterMeta.getParam());
+                    value = request.data().get(namedParam.getName());
+                    if (namedParam.isRequired() && Str.isEmpty(value)) {
+                        errorsList.add(sputs("Unable to find required data param", namedParam.getName()));
+                        break loop;
+                    }
+                    if (value == null) {
+                        value = namedParam.getDefaultValue();
+                    }
+                    break;
                 case PATH_BY_NAME:
                     URINamedParam uriNamedParam = ((URINamedParam) parameterMeta.getParam());
 

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/HttpServerVertx.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/HttpServerVertx.java
@@ -44,6 +44,7 @@ import io.vertx.core.net.JksOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -309,7 +310,7 @@ public class HttpServerVertx implements HttpServer {
 
     private void handleRequestWithNoBody(HttpServerRequest request) {
         final HttpRequest getRequest;
-        getRequest = vertxUtils.createRequest(request, null,
+        getRequest = vertxUtils.createRequest(request, null, new HashMap<>(),
                 simpleHttpServer.getDecorators(), simpleHttpServer.getHttpResponseCreator());
         simpleHttpServer.handleRequest(getRequest);
     }
@@ -325,7 +326,7 @@ public class HttpServerVertx implements HttpServer {
         }
 
         request.bodyHandler((Buffer buffer) -> {
-                final HttpRequest postRequest = vertxUtils.createRequest(request, buffer,
+                final HttpRequest postRequest = vertxUtils.createRequest(request, buffer, new HashMap<>(),
                         simpleHttpServer.getDecorators(), simpleHttpServer.getHttpResponseCreator());
 
                 simpleHttpServer.handleRequest(postRequest);

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/SimpleVertxHttpServerWrapper.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/SimpleVertxHttpServerWrapper.java
@@ -22,6 +22,8 @@ import io.vertx.ext.web.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -137,9 +139,9 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
 
 
         if ( route!=null ) {
-            route.handler(event -> handleHttpRequest(event.request()));
+            route.handler(event -> handleHttpRequest(event.request(), event.data()));
         } else if (router!=null) {
-            router.route().handler(event -> handleHttpRequest(event.request()));
+            router.route().handler(event -> handleHttpRequest(event.request(), event.data()));
         } else {
             httpServer.requestHandler(this::handleHttpRequest);
         }
@@ -156,6 +158,10 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
 
 
     private void handleHttpRequest(final HttpServerRequest request) {
+        handleHttpRequest(request, new HashMap<>());
+    }
+
+    private void handleHttpRequest(final HttpServerRequest request, final Map<String, Object> data) {
 
 
         if (debug) {
@@ -179,7 +185,7 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
                 }
 
                 request.bodyHandler((Buffer buffer) -> {
-                        final HttpRequest postRequest = vertxUtils.createRequest(request, buffer,
+                        final HttpRequest postRequest = vertxUtils.createRequest(request, buffer, data,
                                 simpleHttpServer.getDecorators(), simpleHttpServer.getHttpResponseCreator());
 
                         simpleHttpServer.handleRequest(postRequest);
@@ -194,7 +200,7 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
             case "DELETE":
             case "GET":
                 final HttpRequest getRequest;
-                getRequest = vertxUtils.createRequest(request, null,
+                getRequest = vertxUtils.createRequest(request, null, data,
                         simpleHttpServer.getDecorators(), simpleHttpServer.getHttpResponseCreator());
                 simpleHttpServer.handleRequest(getRequest);
                 break;

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/VertxServerUtils.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/VertxServerUtils.java
@@ -42,6 +42,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -62,6 +63,7 @@ public class VertxServerUtils {
 
     public HttpRequest createRequest(final HttpServerRequest request,
                                      final Buffer buffer,
+                                     final Map<String, Object> data,
                                      final CopyOnWriteArrayList<HttpResponseDecorator> decorators,
                                      final HttpResponseCreator httpResponseCreator) {
 
@@ -74,6 +76,7 @@ public class VertxServerUtils {
         final String requestPath = request.path();
 
         httpRequestBuilder.setId(requestId.incrementAndGet())
+                .setData(data)
                 .setUri(requestPath).setMethod(request.method().toString())
                 .setBodySupplier(() -> buffer == null ?
                         null : buffer.getBytes())


### PR DESCRIPTION
In order to support aspect related operations such as authentication,
session management etc, we need to carry a bag of arbitrary objects on
the request.

When integrated with Vertx, for instance, developers can assign their
own authentication handler that would set some sort of auth context for
the request, which we will pick up in qbit.