### PR TITLE
QBit/Vertx/EventBus bridge working over Node.js bridge to vertx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ activemq-data/
 metastore_db/*
 
 derby.log
+
+qbit/vertx/src/test/javascript/node_modules/

--- a/qbit/build.gradle
+++ b/qbit/build.gradle
@@ -206,7 +206,7 @@ project('vertx') {
 
 
     ext {
-        vertxVersion = '3.1.0'
+        vertxVersion = '3.2.1'
     }
 
     dependencies {
@@ -215,6 +215,10 @@ project('vertx') {
         compile group: 'io.vertx', name: 'vertx-web', version: vertxVersion
 
         testCompile project(':qbit:test-support')
+
+
+        testCompile "io.vertx:vertx-tcp-eventbus-bridge:$vertxVersion"
+        testCompile "io.vertx:vertx-sockjs-service-proxy:$vertxVersion"
     }
 
     uploadArchives {

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/eventbus/bridge/VertxEventBusBridge.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/eventbus/bridge/VertxEventBusBridge.java
@@ -1,0 +1,226 @@
+package io.advantageous.qbit.vertx.eventbus.bridge;
+
+import io.advantageous.boon.core.Predicate;
+import io.advantageous.qbit.json.JsonMapper;
+import io.advantageous.qbit.message.Event;
+import io.advantageous.qbit.message.MethodCall;
+import io.advantageous.qbit.message.MethodCallBuilder;
+import io.advantageous.qbit.message.Response;
+import io.advantageous.qbit.queue.ReceiveQueue;
+import io.advantageous.qbit.queue.SendQueue;
+import io.advantageous.qbit.util.Timer;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+public class VertxEventBusBridge {
+    private final Set<String> addressesToBridge;
+    private final SendQueue<MethodCall<Object>> methodCallSendQueue;
+    private final ReceiveQueue<Response<Object>> receiveResponseQueue;
+    private final Optional<SendQueue<Event<Object>>> eventSendQueue;
+    private final JsonMapper jsonMapper;
+    private final Vertx vertx;
+    private final Predicate<MethodCall<Object>> methodCallPredicate;
+    private final int flushIntervalMS;
+    private final int pollResponsesInterval;
+    private final Timer timer;
+    private long messageId = 0;
+    private final Logger logger = LoggerFactory.getLogger(VertxEventBusBridge.class);
+    private final EventBus vertxEventBus;
+    private List<SendQueue> queuesFlush;
+    private final Map<MessageKey, Message<String>> messageKeyMessageMap;
+
+    public VertxEventBusBridge(final Set<String> addressesToBridge,
+                               final SendQueue<MethodCall<Object>> methodCallSendQueue,
+                               final ReceiveQueue<Response<Object>> receiveResponseQueue,
+                               final SendQueue<Event<Object>> eventSendQueue,
+                               final JsonMapper jsonMapper,
+                               final Vertx vertx,
+                               final EventBus vertxEventBus,
+                               final Timer timer,
+                               final Predicate<MethodCall<Object>> methodCallPredicate,
+                               final int flushIntervalMS,
+                               final int pollResponsesIntervalMS,
+                               final boolean autoStart) {
+
+
+        this.timer = timer;
+        this.vertxEventBus = vertxEventBus;
+        this.addressesToBridge = Collections.unmodifiableSet(addressesToBridge);
+        this.methodCallSendQueue = methodCallSendQueue;
+        this.receiveResponseQueue = receiveResponseQueue;
+        this.eventSendQueue = Optional.ofNullable(eventSendQueue);
+
+        final ArrayList<Object> flushList = new ArrayList<>(2);
+        this.eventSendQueue.ifPresent(flushList::add);
+        flushList.add(methodCallSendQueue);
+        this.queuesFlush = Collections.unmodifiableList(queuesFlush);
+        this.jsonMapper = jsonMapper;
+        this.vertx = vertx;
+        this.methodCallPredicate = methodCallPredicate;
+        this.flushIntervalMS = flushIntervalMS;
+        this.pollResponsesInterval = pollResponsesIntervalMS;
+        this.messageKeyMessageMap = new ConcurrentHashMap<>();
+
+        if (autoStart) {
+            start();
+        }
+
+    }
+
+    private void flush() {
+        queuesFlush.forEach(SendQueue::flushSends);
+    }
+
+    private void start() {
+        /* Flush. */
+        vertx.periodicStream(this.flushIntervalMS).handler(event -> flush());
+        /* Check for responses. */
+        vertx.periodicStream(this.pollResponsesInterval).handler(event -> checkForResponses());
+
+
+        /* Sanity Check. */
+        vertx.periodicStream(1000).handler(event -> sanityCheck());
+
+        /* Register the service addresses */
+        addressesToBridge.stream().forEach(address -> {
+            /* register the consumer per service. */
+            final MessageConsumer<String> consumer = vertxEventBus.consumer(address);
+            consumer.handler(message -> handleIncomingMessage(address, message));
+            consumer.exceptionHandler(error -> logger.error("Error handling address " + address,  error));
+        });
+    }
+
+    private void sanityCheck() {
+        final long now = timer.now();
+
+        if (messageKeyMessageMap.size() > 10_000) {
+            logger.warn("Abnormal program state, it seems async method calls are not returning from service {}", messageKeyMessageMap.size());
+            final List<MessageKey> timedOutKeys = messageKeyMessageMap.keySet().stream()
+                    .filter(messageKey -> (now - messageKey.timeStamp) > 30_000)
+                    .collect(Collectors.toList());
+            logger.warn("There were {} timed out method calls", timedOutKeys.size());
+            timedOutKeys.forEach(messageKeyMessageMap::remove);
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.warn("Outstanding calls {}", messageKeyMessageMap.size());
+            final List<MessageKey> timedOutKeys = messageKeyMessageMap.keySet().stream()
+                    .filter(messageKey -> (now - messageKey.timeStamp) > 10_000)
+                    .collect(Collectors.toList());
+            logger.warn("There are {} out method calls that are older than 10 seconds", timedOutKeys.size());
+
+        }
+    }
+
+    private void handleIncomingMessage(final String address, final Message<String> message) {
+        final Map<String,Object> map = jsonMapper.fromJson(message.body(), Map.class);
+        final Object method = map.get("method");
+        final Object args = map.get("args");
+        final MethodCall<Object> methodCall = MethodCallBuilder
+                .methodCallBuilder()
+                .setAddress(address)
+                .setBody(args)
+                .setTimestamp(this.timer.time())
+                .setName(method.toString())
+                .setId(messageId++)
+                .build();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Calling method ", methodCall.name(), message.body());
+        }
+        if (methodCallPredicate.test(methodCall)) {
+            messageKeyMessageMap.put(new MessageKey(methodCall), message);
+            methodCallSendQueue.send(methodCall);
+        }
+        checkForResponses();
+    }
+
+    private void checkForResponses() {
+        /** Check for responses when the vertx event loop is not busy. */
+        vertx.runOnContext(event -> doCheckForResponses());
+    }
+
+    private void doCheckForResponses() {
+        Response<Object> response = receiveResponseQueue.poll();
+        while (response != null) {
+            handleResponse(response);
+            response = receiveResponseQueue.poll();
+        }
+    }
+
+    private void handleResponse(final Response<Object> response) {
+        final Message<String> message = messageKeyMessageMap.remove(new MessageKey(response));
+        if (message == null) {
+            logger.error("Message {} not found", new MessageKey(response));
+            return;
+        }
+
+        final String json = jsonMapper.toJson(response.body());
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Reply for message {} response {}", message, json);
+        }
+        message.reply(json);
+    }
+
+    private static final class MessageKey {
+        final long id;
+        final long timeStamp;
+        final String address;
+        final String methodName;
+
+        private MessageKey(MethodCall methodCall) {
+            this.id = methodCall.id();
+            this.timeStamp = methodCall.timestamp();
+            this.address = methodCall.address();
+            this.methodName = methodCall.name();
+        }
+
+        private MessageKey(Response response) {
+            this.id = response.id();
+            this.timeStamp = response.timestamp();
+            this.address = response.address();
+            MethodCall methodCall = (MethodCall) response.request();
+            this.methodName = methodCall.name();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MessageKey that = (MessageKey) o;
+            if (id != that.id) return false;
+            if (timeStamp != that.timeStamp) return false;
+            if (address != null ? !address.equals(that.address) : that.address != null) return false;
+            return methodName != null ? methodName.equals(that.methodName) : that.methodName == null;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = (int) (id ^ (id >>> 32));
+            result = 31 * result + (int) (timeStamp ^ (timeStamp >>> 32));
+            result = 31 * result + (address != null ? address.hashCode() : 0);
+            result = 31 * result + (methodName != null ? methodName.hashCode() : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "MessageKey{" +
+                    "id=" + id +
+                    ", timeStamp=" + timeStamp +
+                    ", address='" + address + '\'' +
+                    ", methodName='" + methodName + '\'' +
+                    '}';
+        }
+    }
+
+
+}

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/eventbus/bridge/VertxEventBusBridgeBuilder.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/eventbus/bridge/VertxEventBusBridgeBuilder.java
@@ -1,0 +1,229 @@
+package io.advantageous.qbit.vertx.eventbus.bridge;
+
+import io.advantageous.boon.core.Predicate;
+import io.advantageous.qbit.Factory;
+import io.advantageous.qbit.QBit;
+import io.advantageous.qbit.json.JsonMapper;
+import io.advantageous.qbit.message.Event;
+import io.advantageous.qbit.message.MethodCall;
+import io.advantageous.qbit.message.Response;
+import io.advantageous.qbit.queue.ReceiveQueue;
+import io.advantageous.qbit.queue.SendQueue;
+import io.advantageous.qbit.service.ServiceQueue;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.EventBus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.advantageous.qbit.util.Timer;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Bridges the event bus bridge to QBit.
+ * The vertx event bus is clustered and supports HA.
+ * This bridge builder builds and event bus bridge into the QBit world.
+ * This allows method calls, events and responses to be propagated to/from QBit vertx.
+ */
+public class VertxEventBusBridgeBuilder {
+
+    private final Logger logger = LoggerFactory.getLogger(VertxEventBusBridgeBuilder.class);
+
+    private int flushIntervalMS = 10;
+    private int pollResponsesIntervalMS = 10;
+    private boolean autoStart = true;
+    private SendQueue<MethodCall<Object>> methodCallSendQueue;
+    private SendQueue<Event<Object>> eventSendQueue;
+    private ReceiveQueue<Response<Object>> receiveResponseQueue;
+    private Factory factory;
+    private JsonMapper jsonMapper;
+    private Vertx vertx;
+    private Predicate<MethodCall<Object>> methodCallPredicate = methodCall -> true;
+    private Set<String> addressesToBridge;
+    private EventBus vertxEventBus;
+    private Timer timer;
+
+
+    public static VertxEventBusBridgeBuilder vertxEventBusBridgeBuilder () {
+        return new VertxEventBusBridgeBuilder();
+    }
+    public Timer getTimer() {
+        if (timer == null) {
+            timer = Timer.timer();
+        }
+        return timer;
+    }
+
+    public VertxEventBusBridgeBuilder setTimer(Timer timer) {
+        this.timer = timer;
+        return this;
+    }
+
+    public int getFlushIntervalMS() {
+        return flushIntervalMS;
+    }
+
+    public VertxEventBusBridgeBuilder setFlushIntervalMS(int flushIntervalMS) {
+        this.flushIntervalMS = flushIntervalMS;
+        return this;
+    }
+
+    public int getPollResponsesIntervalMS() {
+        return pollResponsesIntervalMS;
+    }
+
+    public VertxEventBusBridgeBuilder setPollResponsesIntervalMS(int pollResponsesIntervalMS) {
+        this.pollResponsesIntervalMS = pollResponsesIntervalMS;
+        return this;
+    }
+
+    public boolean isAutoStart() {
+        return autoStart;
+    }
+
+    public VertxEventBusBridgeBuilder setAutoStart(boolean autoStart) {
+        this.autoStart = autoStart;
+        return this;
+    }
+
+    public SendQueue<MethodCall<Object>> getMethodCallSendQueue() {
+
+        Objects.requireNonNull(methodCallSendQueue, "methodCallSendQueue must be set");
+        return methodCallSendQueue;
+    }
+
+    public VertxEventBusBridgeBuilder setMethodCallSendQueue(SendQueue<MethodCall<Object>> methodCallSendQueue) {
+        this.methodCallSendQueue = methodCallSendQueue;
+        return this;
+    }
+
+    public SendQueue<Event<Object>> getEventSendQueue() {
+
+        if (eventSendQueue == null) {
+            logger.debug("Event Queue was not sent");
+        }
+        return eventSendQueue;
+    }
+
+    public VertxEventBusBridgeBuilder setEventSendQueue(SendQueue<Event<Object>> eventSendQueue) {
+        this.eventSendQueue = eventSendQueue;
+        return this;
+    }
+
+    public ReceiveQueue<Response<Object>> getReceiveResponseQueue() {
+        Objects.requireNonNull(receiveResponseQueue, "receiveResponseQueue must be set");
+        return receiveResponseQueue;
+    }
+
+    public VertxEventBusBridgeBuilder setReceiveResponseQueue(ReceiveQueue<Response<Object>> receiveResponseQueue) {
+        this.receiveResponseQueue = receiveResponseQueue;
+        return this;
+    }
+
+    public Factory getFactory() {
+        if (factory == null) {
+            logger.debug("Factory not set using default QBit factory");
+            factory = QBit.factory();
+        }
+        return factory;
+    }
+
+    public VertxEventBusBridgeBuilder setFactory(Factory factory) {
+        this.factory = factory;
+        return this;
+    }
+
+    public JsonMapper getJsonMapper() {
+        if (jsonMapper == null) {
+            logger.debug("JsonMapper not set using default JsonMapper");
+            jsonMapper = getFactory().createJsonMapper();
+        }
+        return jsonMapper;
+    }
+
+    public VertxEventBusBridgeBuilder setJsonMapper(JsonMapper jsonMapper) {
+        this.jsonMapper = jsonMapper;
+        return this;
+    }
+
+    public Vertx getVertx() {
+        if (vertx == null) {
+            logger.warn("Vertx not set using default Vertx which is likely not what you want!!");
+            vertx = Vertx.vertx();
+        }
+        return vertx;
+    }
+
+    public VertxEventBusBridgeBuilder setVertx(Vertx vertx) {
+        this.vertx = vertx;
+        return this;
+    }
+
+    public Predicate<MethodCall<Object>> getMethodCallPredicate() {
+        return methodCallPredicate;
+    }
+
+    public VertxEventBusBridgeBuilder setMethodCallPredicate(Predicate<MethodCall<Object>> methodCallPredicate) {
+        this.methodCallPredicate = methodCallPredicate;
+        return this;
+    }
+
+    public Set<String> getAddressesToBridge() {
+        Objects.requireNonNull(addressesToBridge, "Addresses to bridge must be set");
+        return addressesToBridge;
+    }
+
+    public VertxEventBusBridgeBuilder setAddressesToBridge(Set<String> addressesToBridge) {
+        if (this.addressesToBridge != null) {
+            logger.warn("Addresses were already set, overwriting addresses");
+        }
+        this.addressesToBridge = addressesToBridge;
+        return this;
+    }
+
+
+    public VertxEventBusBridgeBuilder addBridgeAddress(String address) {
+
+        if (addressesToBridge == null) {
+            addressesToBridge = new HashSet<>();
+        }
+        addressesToBridge.add(address);
+        return this;
+    }
+
+    public EventBus getVertxEventBus() {
+        if (vertxEventBus == null) {
+            vertxEventBus = getVertx().eventBus();
+        }
+        return vertxEventBus;
+    }
+
+    public VertxEventBusBridgeBuilder setVertxEventBus(EventBus vertxEventBus) {
+        this.vertxEventBus = vertxEventBus;
+        return this;
+    }
+
+    public VertxEventBusBridge build() {
+        final VertxEventBusBridge bridge = new VertxEventBusBridge(this.getAddressesToBridge(),
+                this.getMethodCallSendQueue(),
+                this.getReceiveResponseQueue(),
+                this.getEventSendQueue(),
+                this.getJsonMapper(),
+                this.getVertx(),
+                this.getVertxEventBus(),
+                this.getTimer(),
+                this.getMethodCallPredicate(),
+                this.getFlushIntervalMS(),
+                this.getPollResponsesIntervalMS(),
+                this.isAutoStart());
+        return bridge;
+    }
+
+    public VertxEventBusBridgeBuilder setServiceQueue(ServiceQueue serviceQueue) {
+        this.setEventSendQueue(serviceQueue.events());
+        this.setMethodCallSendQueue(serviceQueue.requests());
+        this.setReceiveResponseQueue(serviceQueue.responses());
+        return this;
+    }
+}

--- a/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/BridgeToTestNodeJS.java
+++ b/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/BridgeToTestNodeJS.java
@@ -1,0 +1,83 @@
+package io.advantageous.qbit.vertx;
+
+import io.advantageous.qbit.service.ServiceBuilder;
+import io.advantageous.qbit.service.ServiceQueue;
+import io.advantageous.qbit.vertx.eventbus.bridge.VertxEventBusBridgeBuilder;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.sockjs.BridgeOptions;
+import io.vertx.ext.web.handler.sockjs.PermittedOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSHandler;
+
+public class BridgeToTestNodeJS extends AbstractVerticle {
+
+
+    public static class TestService {
+
+        public boolean test(final String newValue) {
+
+            System.out.println("HERE::" + newValue);
+            return true;
+        }
+    }
+
+    @Override
+    public void start() throws Exception {
+
+        /* test service */
+        final TestService testService = new TestService();
+
+        /* address */
+        final String address = "testservice";
+
+        /* service builder */
+        final ServiceBuilder serviceBuilder = ServiceBuilder.serviceBuilder();
+        serviceBuilder.setServiceObject(testService);
+        final ServiceQueue serviceQueue = serviceBuilder.build();
+
+
+
+
+        /* vertx event bus bridge to qbit. */
+        final VertxEventBusBridgeBuilder vertxEventBusBridgeBuilder = VertxEventBusBridgeBuilder
+                .vertxEventBusBridgeBuilder()
+                .setVertx(vertx);
+
+        vertxEventBusBridgeBuilder.addBridgeAddress(address);
+
+        final Router router = Router.router(vertx);
+
+
+        router.route("/health/").handler(routingContext -> routingContext.response().end("\"ok\""));
+
+
+            /* Configure bridge at this HTTP/WebSocket URI. */
+        router.route("/eventbus/*").handler(SockJSHandler.create(vertx).bridge(
+                new BridgeOptions()
+                        .addInboundPermitted(new PermittedOptions().setAddress(address))
+                        .addOutboundPermitted(new PermittedOptions().setAddress(address))
+        ));
+
+
+        vertxEventBusBridgeBuilder.setServiceQueue(serviceQueue);
+        serviceQueue.start(); //startall not supported yet for bridge.
+        vertxEventBusBridgeBuilder.build();
+
+
+        vertx.createHttpServer().requestHandler(router::accept).listen(8080);
+
+        System.out.println("Bound to 8080");
+    }
+
+    public static void main(String... args) throws Exception {
+
+
+        Vertx vertx = Vertx.vertx();
+
+        vertx.deployVerticle(new BridgeToTestNodeJS());
+
+    }
+}

--- a/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/BridgeToTestNodeJS.java
+++ b/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/BridgeToTestNodeJS.java
@@ -1,12 +1,11 @@
 package io.advantageous.qbit.vertx;
 
+import io.advantageous.qbit.reactive.Callback;
 import io.advantageous.qbit.service.ServiceBuilder;
 import io.advantageous.qbit.service.ServiceQueue;
 import io.advantageous.qbit.vertx.eventbus.bridge.VertxEventBusBridgeBuilder;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpServerRequest;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.sockjs.BridgeOptions;
 import io.vertx.ext.web.handler.sockjs.PermittedOptions;
@@ -16,11 +15,9 @@ public class BridgeToTestNodeJS extends AbstractVerticle {
 
 
     public static class TestService {
-
-        public boolean test(final String newValue) {
-
+        public void test(Callback<Boolean> callback, final String newValue) {
             System.out.println("HERE::" + newValue);
-            return true;
+            callback.returnThis(true);
         }
     }
 

--- a/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/eventbus/bridge/VertxEventBusBridgeTest.java
+++ b/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/eventbus/bridge/VertxEventBusBridgeTest.java
@@ -1,21 +1,68 @@
 package io.advantageous.qbit.vertx.eventbus.bridge;
 
-import io.advantageous.boon.core.Sys;
-import io.advantageous.qbit.reactive.Callback;
 import io.advantageous.qbit.service.ServiceBuilder;
 import io.advantageous.qbit.service.ServiceQueue;
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.Message;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
 
 
 public class VertxEventBusBridgeTest {
 
+    @Test
+    public void test() throws Exception {
+
+        /* test service */
+        final TestService testService = new TestService();
+
+        /* address */
+        final String address = "testservice";
+
+        /* service builder */
+        final ServiceBuilder serviceBuilder = ServiceBuilder.serviceBuilder();
+        serviceBuilder.setServiceObject(testService);
+        final ServiceQueue serviceQueue = serviceBuilder.build();
+
+        /* vertx event bus bridge to qbit. */
+        final VertxEventBusBridgeBuilder vertxEventBusBridgeBuilder = VertxEventBusBridgeBuilder.vertxEventBusBridgeBuilder();
+        vertxEventBusBridgeBuilder.addBridgeAddress(address);
+        vertxEventBusBridgeBuilder.setServiceQueue(serviceQueue);
+        serviceQueue.start(); //startall not supported yet for bridge.
+        vertxEventBusBridgeBuilder.build();
+
+
+        /* latch so we can test results coming back from bridge. */
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+        /* grab vertx from the bridge. */
+        final Vertx vertx = vertxEventBusBridgeBuilder.getVertx();
+
+        final AtomicReference<AsyncResult<Message<Object>>> ref = new AtomicReference<>();
+
+        /* calling using the event bus, and use latch to wait for the return. */
+        vertx.eventBus().send(address, "{'method':'test', 'args':['hello']}".replaceAll("'", "\""),
+                reply -> {
+                    ref.set(reply);
+                    countDownLatch.countDown();
+                });
+
+        countDownLatch.await();
+
+        assertEquals("hello", testService.value.get());
+
+        vertx.close();
+    }
+
+
     public static class TestService {
         AtomicReference<String> value = new AtomicReference<>();
+
         public boolean test(final String newValue) {
 
             System.out.println("HERE::" + newValue);
@@ -23,40 +70,6 @@ public class VertxEventBusBridgeTest {
 
             return true;
         }
-    }
-
-    public  interface ITestService {
-        void test(Callback<Boolean> callback, final String newValue, final CountDownLatch countDownLatch);
-    }
-
-
-    @Test
-    public void test() throws Exception {
-
-        final TestService testService = new TestService();
-
-
-
-        final ServiceBuilder serviceBuilder = ServiceBuilder.serviceBuilder();
-        serviceBuilder.setServiceObject(testService);
-        final ServiceQueue serviceQueue = serviceBuilder.build();
-
-        final VertxEventBusBridgeBuilder vertxEventBusBridgeBuilder = VertxEventBusBridgeBuilder.vertxEventBusBridgeBuilder();
-        vertxEventBusBridgeBuilder.addBridgeAddress("testservice");
-
-        vertxEventBusBridgeBuilder.setServiceQueue(serviceQueue);
-
-        serviceQueue.startAll();
-        final ITestService proxy = serviceQueue.createProxyWithAutoFlush(ITestService.class, 1, TimeUnit.MILLISECONDS);
-
-        final CountDownLatch countDownLatch = new CountDownLatch(1);
-        proxy.test(aBoolean -> System.out.println("HERE::AFTER"), "FOO", countDownLatch);
-        countDownLatch.await();
-
-        Vertx vertx = vertxEventBusBridgeBuilder.getVertx();
-
-        vertx.eventBus().send("testservice", "{'method':'test', }");
-
     }
 
 }

--- a/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/eventbus/bridge/VertxEventBusBridgeTest.java
+++ b/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/eventbus/bridge/VertxEventBusBridgeTest.java
@@ -1,0 +1,62 @@
+package io.advantageous.qbit.vertx.eventbus.bridge;
+
+import io.advantageous.boon.core.Sys;
+import io.advantageous.qbit.reactive.Callback;
+import io.advantageous.qbit.service.ServiceBuilder;
+import io.advantageous.qbit.service.ServiceQueue;
+import io.vertx.core.Vertx;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+
+public class VertxEventBusBridgeTest {
+
+    public static class TestService {
+        AtomicReference<String> value = new AtomicReference<>();
+        public boolean test(final String newValue) {
+
+            System.out.println("HERE::" + newValue);
+            value.set(newValue);
+
+            return true;
+        }
+    }
+
+    public  interface ITestService {
+        void test(Callback<Boolean> callback, final String newValue, final CountDownLatch countDownLatch);
+    }
+
+
+    @Test
+    public void test() throws Exception {
+
+        final TestService testService = new TestService();
+
+
+
+        final ServiceBuilder serviceBuilder = ServiceBuilder.serviceBuilder();
+        serviceBuilder.setServiceObject(testService);
+        final ServiceQueue serviceQueue = serviceBuilder.build();
+
+        final VertxEventBusBridgeBuilder vertxEventBusBridgeBuilder = VertxEventBusBridgeBuilder.vertxEventBusBridgeBuilder();
+        vertxEventBusBridgeBuilder.addBridgeAddress("testservice");
+
+        vertxEventBusBridgeBuilder.setServiceQueue(serviceQueue);
+
+        serviceQueue.startAll();
+        final ITestService proxy = serviceQueue.createProxyWithAutoFlush(ITestService.class, 1, TimeUnit.MILLISECONDS);
+
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        proxy.test(aBoolean -> System.out.println("HERE::AFTER"), "FOO", countDownLatch);
+        countDownLatch.await();
+
+        Vertx vertx = vertxEventBusBridgeBuilder.getVertx();
+
+        vertx.eventBus().send("testservice", "{'method':'test', }");
+
+    }
+
+}

--- a/qbit/vertx/src/test/javascript/package.json
+++ b/qbit/vertx/src/test/javascript/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test-eventbus-from-node",
+  "version": "1.0.0",
+  "description": "Test scripts to try out event bus bridge from node",
+  "main": "testClient.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "Apache 2",
+  "dependencies": {
+    "vertx3-eventbus-client": "^3.2.1"
+  }
+}

--- a/qbit/vertx/src/test/javascript/testClient.js
+++ b/qbit/vertx/src/test/javascript/testClient.js
@@ -1,0 +1,48 @@
+const EventBus = require("vertx3-eventbus-client");
+
+
+function connect(url) {
+  console.log(`Connecting to vertx: ${url}`);
+  return new Promise((resolve, reject) => {
+    try {
+      const eventBus = new EventBus(url);
+      eventBus.onopen = () => {
+        console.log(`established connection to vertx on ${url}`);
+        resolve(eventBus);
+      };
+      eventBus.onclose = () => {
+        console.log(`connection closed on ${url}`);
+      };
+      eventBus.onerror = (error) => {
+        console.log("there was an error: ", error);
+        reject(error);
+      }
+    } catch (e) {
+      console.log(`exception encountered connecting to ${url}`);
+      reject(e);
+    }
+  });
+}
+
+connect('http://localhost:8080/eventbus/').then((eventBus) => {
+
+  console.log("HERE.....")
+
+  eventBus.send("testservice", '{"method":"test", "args":["hello"]}', (error, result)=>{
+
+    if (error) {
+      console.log("error message ", error);
+    } else {
+      console.log("result message ", result);
+    }
+
+
+  });
+
+}).catch((error) => {
+  console.log(error)
+});
+
+setInterval(function () {
+  console.log('Waiting...');
+}, 3000);

--- a/qbit/vertx/src/test/javascript/testClient.js
+++ b/qbit/vertx/src/test/javascript/testClient.js
@@ -25,20 +25,15 @@ function connect(url) {
 }
 
 connect('http://localhost:8080/eventbus/').then((eventBus) => {
-
   console.log("HERE.....")
-
-  eventBus.send("testservice", '{"method":"test", "args":["hello"]}', (error, result)=>{
-
+  eventBus.send("testservice",
+            JSON.stringify({"method":"test", "args":["hello"]}), (error, result)=>{
     if (error) {
       console.log("error message ", error);
     } else {
       console.log("result message ", result);
     }
-
-
   });
-
 }).catch((error) => {
   console.log(error)
 });

--- a/qbit/vertx/src/test/resources/logback.xml
+++ b/qbit/vertx/src/test/resources/logback.xml
@@ -24,7 +24,7 @@
         </encoder>
     </appender>
 
-    <root level="info">
+    <root level="debug">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
QBit/Vertx/EventBus bridge working over Node.js bridge to vertx.

Using the vertx bridge from node.

```javascript
const EventBus = require("vertx3-eventbus-client");


function connect(url) {
  console.log(`Connecting to vertx: ${url}`);
  return new Promise((resolve, reject) => {
    try {
      const eventBus = new EventBus(url);
      eventBus.onopen = () => {
        console.log(`established connection to vertx on ${url}`);
        resolve(eventBus);
      };
      eventBus.onclose = () => {
        console.log(`connection closed on ${url}`);
      };
      eventBus.onerror = (error) => {
        console.log("there was an error: ", error);
        reject(error);
      }
    } catch (e) {
      console.log(`exception encountered connecting to ${url}`);
      reject(e);
    }
  });
}

connect('http://localhost:8080/eventbus/').then((eventBus) => {
  console.log("HERE.....")
  eventBus.send("testservice",
            JSON.stringify({"method":"test", "args":["hello"]}), (error, result)=>{
    if (error) {
      console.log("error message ", error);
    } else {
      console.log("result message ", result);
    }
  });
}).catch((error) => {
  console.log(error)
});

setInterval(function () {
  console.log('Waiting...');
}, 3000);
```

To call 

```java
   public static class TestService {

        public boolean test(final String newValue) {

            System.out.println("HERE::" + newValue);
            return true;
        }
    }
```