### PR TITLE
Improved examples and integration. Bridge now works with service bundles and server endpoints.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ activemq-data/
 metastore_db/*
 derby.log
 qbit/vertx/src/test/javascript/node_modules/
+examples/standalone/src/main/javascript/node_modules/

--- a/examples/standalone/src/main/java/io/advantageous/qbit/example/vertx/eventbus/bridge/Employee.java
+++ b/examples/standalone/src/main/java/io/advantageous/qbit/example/vertx/eventbus/bridge/Employee.java
@@ -1,0 +1,46 @@
+package io.advantageous.qbit.example.vertx.eventbus.bridge;
+
+public class Employee {
+
+
+    private final String id;
+    private final String firstName;
+    private final String lastName;
+    private final int birthYear;
+    private final long socialSecurityNumber;
+
+    public Employee(String id, String firstName, String lastName, int birthYear, long socialSecurityNumber) {
+        this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.birthYear = birthYear;
+        this.socialSecurityNumber = socialSecurityNumber;
+    }
+
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public int getBirthYear() {
+        return birthYear;
+    }
+
+    public long getSocialSecurityNumber() {
+        return socialSecurityNumber;
+    }
+
+    @Override
+    public String toString() {
+        return "Employee{" +
+                "firstName='" + firstName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", birthYear=" + birthYear +
+                ", socialSecurityNumber=" + socialSecurityNumber +
+                '}';
+    }
+}

--- a/examples/standalone/src/main/java/io/advantageous/qbit/example/vertx/eventbus/bridge/EmployeeService.java
+++ b/examples/standalone/src/main/java/io/advantageous/qbit/example/vertx/eventbus/bridge/EmployeeService.java
@@ -1,0 +1,29 @@
+package io.advantageous.qbit.example.vertx.eventbus.bridge;
+
+import io.advantageous.qbit.annotation.RequestMapping;
+import io.advantageous.qbit.annotation.RequestParam;
+import io.advantageous.qbit.annotation.http.GET;
+import io.advantageous.qbit.annotation.http.POST;
+import io.advantageous.qbit.reactive.Callback;
+
+@RequestMapping("/es/1.0")
+public class EmployeeService {
+
+    @POST("/employee/")
+    public boolean addEmployee(final Employee employee) {
+        System.out.println(employee);
+        return true;
+    }
+
+    @POST("/employee/err/")
+    public boolean addEmployeeError(final Employee employee) {
+        throw new IllegalStateException("Employee can't be added");
+    }
+
+    @GET("/employee/")
+    public void getEmployee(final Callback<Employee> callback,
+            @RequestParam("id") final String id) {
+        callback.returnThis(new Employee(id, "Bob", "Jingles", 1962, 999999999));
+    }
+
+}

--- a/examples/standalone/src/main/java/io/advantageous/qbit/example/vertx/eventbus/bridge/EventBusBridgeExample.java
+++ b/examples/standalone/src/main/java/io/advantageous/qbit/example/vertx/eventbus/bridge/EventBusBridgeExample.java
@@ -1,0 +1,82 @@
+package io.advantageous.qbit.example.vertx.eventbus.bridge;
+
+import io.advantageous.qbit.admin.ManagedServiceBuilder;
+import io.advantageous.qbit.http.server.HttpServer;
+import io.advantageous.qbit.server.ServiceEndpointServer;
+import io.advantageous.qbit.vertx.eventbus.bridge.VertxEventBusBridgeBuilder;
+import io.advantageous.qbit.vertx.http.VertxHttpServerBuilder;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.sockjs.BridgeOptions;
+import io.vertx.ext.web.handler.sockjs.PermittedOptions;
+import io.vertx.ext.web.handler.sockjs.SockJSHandler;
+
+/**
+ * Send JSON POST.
+ * <code>
+ *     curl -X POST -H "Content-Type: application/json" \
+ *     http://localhost:8080/es/1.0/employee/ \
+ *     -d '{"id":"5","firstName":"Bob","lastName":"Jingles","birthYear":1962,"socialSecurityNumber":999999999}'
+ * </code>
+ *
+ * Get JSON
+ *
+ * <code>
+ *      curl http://localhost:8080/es/1.0/employee/?id=5
+ * </code>
+ */
+public class EventBusBridgeExample extends AbstractVerticle {
+
+    @Override
+    public void start() throws Exception {
+
+
+        final String address = "/es/1.0";
+        final EmployeeService employeeService = new EmployeeService();
+        final VertxEventBusBridgeBuilder vertxEventBusBridgeBuilder = VertxEventBusBridgeBuilder
+                .vertxEventBusBridgeBuilder()
+                .setVertx(vertx);
+        final ManagedServiceBuilder managedServiceBuilder = ManagedServiceBuilder.managedServiceBuilder();
+        final Router router = Router.router(vertx);
+
+
+        managedServiceBuilder.setRootURI("/");
+        vertxEventBusBridgeBuilder.addBridgeAddress(address);
+        /* Route everything under address to QBit http server. */
+        router.route().path(address + "/*");
+        /* Configure bridge at this HTTP/WebSocket URI. */
+        router.route("/eventbus/*").handler(SockJSHandler.create(vertx).bridge(
+                new BridgeOptions()
+                        .addInboundPermitted(new PermittedOptions().setAddress(address))
+                        .addOutboundPermitted(new PermittedOptions().setAddress(address))
+        ));
+
+        final io.vertx.core.http.HttpServer vertxHttpServer = vertx.createHttpServer();
+        /*
+         * Use the VertxHttpServerBuilder which is a special builder for Vertx/Qbit integration.
+         */
+        final HttpServer httpServer = VertxHttpServerBuilder.vertxHttpServerBuilder()
+                .setRouter(router)
+                .setHttpServer(vertxHttpServer)
+                .setVertx(vertx)
+                .build();
+
+
+        final ServiceEndpointServer endpointServer = managedServiceBuilder.getEndpointServerBuilder()
+                .setHttpServer(httpServer)
+                .addService(employeeService)
+                .build();
+        vertxEventBusBridgeBuilder.setServiceBundle(endpointServer.serviceBundle()).build();
+        endpointServer.startServer();
+        vertxHttpServer.requestHandler(router::accept).listen(8080);
+
+
+    }
+
+
+    public static void main(String... args) throws Exception {
+        final Vertx vertx = Vertx.vertx();
+        vertx.deployVerticle(new EventBusBridgeExample());
+    }
+}

--- a/examples/standalone/src/main/javascript/package.json
+++ b/examples/standalone/src/main/javascript/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "test-eventbus-from-node",
+  "version": "1.0.0",
+  "description": "Test scripts to try out event bus bridge from node",
+  "main": "testClient.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "Apache 2",
+  "dependencies": {
+    "vertx3-eventbus-client": "^3.2.1"
+  }
+}

--- a/examples/standalone/src/main/javascript/testClient.js
+++ b/examples/standalone/src/main/javascript/testClient.js
@@ -1,0 +1,58 @@
+const EventBus = require("vertx3-eventbus-client");
+
+
+function connect(url) {
+  console.log(`Connecting to vertx: ${url}`);
+  return new Promise((resolve, reject) => {
+    try {
+      const eventBus = new EventBus(url);
+      eventBus.onopen = () => {
+        console.log(`established connection to vertx on ${url}`);
+        resolve(eventBus);
+      };
+      eventBus.onclose = () => {
+        console.log(`connection closed on ${url}`);
+      };
+      eventBus.onerror = (error) => {
+        console.log("there was an error: ", error);
+        reject(error);
+      }
+    } catch (e) {
+      console.log(`exception encountered connecting to ${url}`);
+      reject(e);
+    }
+  });
+}
+
+connect('http://localhost:8080/eventbus/').then((eventBus) => {
+  console.log("HERE.....")
+  eventBus.send("/es/1.0",     JSON.stringify(
+    { "method":"addEmployee",
+      "args":
+        [{"id":"5","firstName":"Bob","lastName":"Jingles","birthYear":1962,"socialSecurityNumber":999999999}]
+    }), (error, result)=>{
+
+    /* Did vertx event bus return an error. */
+    if (error) {
+      console.log("error message from vertx or socketJS ", error);
+    } else {
+      const response = JSON.parse (result.body);
+      console.log("result message from Vertx", result);
+      console.log("response message from QBit", response);
+
+      /* Did QBit return an error. */
+      if (response.error) {
+        console.log("error cause message ", response['cause']);
+      } else {
+        /*If successful show response from QBit. */
+        console.log("Success ", response['returned'])
+      }
+    }
+  });
+}).catch((error) => {
+  console.log(error)
+});
+
+setInterval(function () {
+  console.log('Waiting...');
+}, 3000);

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/eventbus/bridge/VertxEventBusBridgeBuilder.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/eventbus/bridge/VertxEventBusBridgeBuilder.java
@@ -9,6 +9,7 @@ import io.advantageous.qbit.message.MethodCall;
 import io.advantageous.qbit.message.Response;
 import io.advantageous.qbit.queue.ReceiveQueue;
 import io.advantageous.qbit.queue.SendQueue;
+import io.advantageous.qbit.service.ServiceBundle;
 import io.advantageous.qbit.service.ServiceQueue;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
@@ -31,11 +32,8 @@ public class VertxEventBusBridgeBuilder {
     private final Logger logger = LoggerFactory.getLogger(VertxEventBusBridgeBuilder.class);
 
     private int flushIntervalMS = 10;
-    private int pollResponsesIntervalMS = 10;
     private boolean autoStart = true;
     private SendQueue<MethodCall<Object>> methodCallSendQueue;
-    private SendQueue<Event<Object>> eventSendQueue;
-    private ReceiveQueue<Response<Object>> receiveResponseQueue;
     private Factory factory;
     private JsonMapper jsonMapper;
     private Vertx vertx;
@@ -69,14 +67,6 @@ public class VertxEventBusBridgeBuilder {
         return this;
     }
 
-    public int getPollResponsesIntervalMS() {
-        return pollResponsesIntervalMS;
-    }
-
-    public VertxEventBusBridgeBuilder setPollResponsesIntervalMS(int pollResponsesIntervalMS) {
-        this.pollResponsesIntervalMS = pollResponsesIntervalMS;
-        return this;
-    }
 
     public boolean isAutoStart() {
         return autoStart;
@@ -88,36 +78,12 @@ public class VertxEventBusBridgeBuilder {
     }
 
     public SendQueue<MethodCall<Object>> getMethodCallSendQueue() {
-
         Objects.requireNonNull(methodCallSendQueue, "methodCallSendQueue must be set");
         return methodCallSendQueue;
     }
 
     public VertxEventBusBridgeBuilder setMethodCallSendQueue(SendQueue<MethodCall<Object>> methodCallSendQueue) {
         this.methodCallSendQueue = methodCallSendQueue;
-        return this;
-    }
-
-    public SendQueue<Event<Object>> getEventSendQueue() {
-
-        if (eventSendQueue == null) {
-            logger.debug("Event Queue was not sent");
-        }
-        return eventSendQueue;
-    }
-
-    public VertxEventBusBridgeBuilder setEventSendQueue(SendQueue<Event<Object>> eventSendQueue) {
-        this.eventSendQueue = eventSendQueue;
-        return this;
-    }
-
-    public ReceiveQueue<Response<Object>> getReceiveResponseQueue() {
-        Objects.requireNonNull(receiveResponseQueue, "receiveResponseQueue must be set");
-        return receiveResponseQueue;
-    }
-
-    public VertxEventBusBridgeBuilder setReceiveResponseQueue(ReceiveQueue<Response<Object>> receiveResponseQueue) {
-        this.receiveResponseQueue = receiveResponseQueue;
         return this;
     }
 
@@ -142,7 +108,7 @@ public class VertxEventBusBridgeBuilder {
         return jsonMapper;
     }
 
-    public VertxEventBusBridgeBuilder setJsonMapper(JsonMapper jsonMapper) {
+    public VertxEventBusBridgeBuilder setJsonMapper(final JsonMapper jsonMapper) {
         this.jsonMapper = jsonMapper;
         return this;
     }
@@ -164,7 +130,7 @@ public class VertxEventBusBridgeBuilder {
         return methodCallPredicate;
     }
 
-    public VertxEventBusBridgeBuilder setMethodCallPredicate(Predicate<MethodCall<Object>> methodCallPredicate) {
+    public VertxEventBusBridgeBuilder setMethodCallPredicate(final Predicate<MethodCall<Object>> methodCallPredicate) {
         this.methodCallPredicate = methodCallPredicate;
         return this;
     }
@@ -174,7 +140,7 @@ public class VertxEventBusBridgeBuilder {
         return addressesToBridge;
     }
 
-    public VertxEventBusBridgeBuilder setAddressesToBridge(Set<String> addressesToBridge) {
+    public VertxEventBusBridgeBuilder setAddressesToBridge(final Set<String> addressesToBridge) {
         if (this.addressesToBridge != null) {
             logger.warn("Addresses were already set, overwriting addresses");
         }
@@ -218,9 +184,12 @@ public class VertxEventBusBridgeBuilder {
     }
 
     public VertxEventBusBridgeBuilder setServiceQueue(ServiceQueue serviceQueue) {
-        this.setEventSendQueue(serviceQueue.events());
         this.setMethodCallSendQueue(serviceQueue.requests());
-        this.setReceiveResponseQueue(serviceQueue.responses());
+        return this;
+    }
+
+    public VertxEventBusBridgeBuilder setServiceBundle(ServiceBundle serviceBundle) {
+        this.setMethodCallSendQueue(serviceBundle.methodSendQueue());
         return this;
     }
 }

--- a/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/BridgeToTestNodeJS.java
+++ b/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/BridgeToTestNodeJS.java
@@ -60,7 +60,7 @@ public class BridgeToTestNodeJS extends AbstractVerticle {
 
 
         vertxEventBusBridgeBuilder.setServiceQueue(serviceQueue);
-        serviceQueue.start(); //startall not supported yet for bridge.
+        serviceQueue.startAll(); //startall not supported yet for bridge.
         vertxEventBusBridgeBuilder.build();
 
 


### PR DESCRIPTION

Relates to: https://github.com/advantageous/qbit/issues/641

Improved examples and integration. Bridge now works with service bundles and server endpoints.


 ```java

@RequestMapping("/es/1.0")
public class EmployeeService {

    @POST("/employee/")
    public boolean addEmployee(final Employee employee) {
        System.out.println(employee);
        return true;
    }

    @POST("/employee/err/")
    public boolean addEmployeeError(final Employee employee) {
        throw new IllegalStateException("Employee can't be added");
    }

    @GET("/employee/")
    public void getEmployee(final Callback<Employee> callback,
            @RequestParam("id") final String id) {
        callback.returnThis(new Employee(id, "Bob", "Jingles", 1962, 999999999));
    }

}```

The above is  a sample service.

To invoke the above from node using vertx event bus.


 ```javascript
  eventBus.send("/es/1.0",     JSON.stringify(
    { "method":"addEmployee",
      "args":
        [{"id":"5","firstName":"Bob","lastName":"Jingles","birthYear":1962,"socialSecurityNumber":999999999}]
    }), (error, result)=>{

    /* Did vertx event bus return an error. */
    if (error) {
      console.log("error message from vertx or socketJS ", error);
    } else {
      const response = JSON.parse (result.body);
      console.log("result message from Vertx", result);
      console.log("response message from QBit", response);

      /* Did QBit return an error. */
      if (response.error) {
        console.log("error cause message ", response['cause']);
      } else {
        /*If successful show response from QBit. */
        console.log("Success ", response['returned'])
      }
    }
  });
```

This can also be invoked via QBit RPC Websocket and REST.

```bash
$ curl -X POST -H "Content-Type: application/json" http://localhost:8080/es/1.0/employee/ \
 -d '{"id":"5","firstName":"Bob","lastName":"Jingles","birthYear":1962,"socialSecurityNumber":999999999}'
```

```bash
$ curl http://localhost:8080/es/1.0/employee/?id=5
```

To set this up, you need the `VertxEventBusBridgeBuilder/VertxEventBusBridge`.

```java


        final String address = "/es/1.0";
        final EmployeeService employeeService = new EmployeeService();
        final VertxEventBusBridgeBuilder vertxEventBusBridgeBuilder = VertxEventBusBridgeBuilder
                .vertxEventBusBridgeBuilder()
                .setVertx(vertx);
        final ManagedServiceBuilder managedServiceBuilder = ManagedServiceBuilder.managedServiceBuilder();
        final Router router = Router.router(vertx);


        managedServiceBuilder.setRootURI("/");
        vertxEventBusBridgeBuilder.addBridgeAddress(address);
        /* Route everything under address to QBit http server. */
        router.route().path(address + "/*");
        /* Configure bridge at this HTTP/WebSocket URI. */
        router.route("/eventbus/*").handler(SockJSHandler.create(vertx).bridge(
                new BridgeOptions()
                        .addInboundPermitted(new PermittedOptions().setAddress(address))
                        .addOutboundPermitted(new PermittedOptions().setAddress(address))
        ));

        final io.vertx.core.http.HttpServer vertxHttpServer = vertx.createHttpServer();
        /*
         * Use the VertxHttpServerBuilder which is a special builder for Vertx/Qbit integration.
         */
        final HttpServer httpServer = VertxHttpServerBuilder.vertxHttpServerBuilder()
                .setRouter(router)
                .setHttpServer(vertxHttpServer)
                .setVertx(vertx)
                .build();


        final ServiceEndpointServer endpointServer = managedServiceBuilder.getEndpointServerBuilder()
                .setHttpServer(httpServer)
                .addService(employeeService)
                .build();
        vertxEventBusBridgeBuilder.setServiceBundle(endpointServer.serviceBundle()).build();
        endpointServer.startServer();
        vertxHttpServer.requestHandler(router::accept).listen(8080);
```