### PR TITLE
Bug 660 fix for HttpClient fast fail on sendHttpRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 The Java microservice lib. QBit is a reactive programming lib for building microservices - JSON, HTTP, WebSocket, and REST. QBit uses reactive programming to build elastic REST, and WebSockets based cloud friendly, web services. SOA evolved for mobile and cloud. ServiceDiscovery, Health, reactive StatService, events, Java idiomatic reactive programming for Microservices.
 
-
-
 Got a question? Ask here: [QBit Google Group](https://groups.google.com/forum/#!forum/qbit-microservice).
 
 Everything is a queue. You have a choice. You can embrace it and control it. You can optimize for it.

--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,8 @@
 
 ext {
     projectVersion = '0.9.3-RC4-SNAPSHOT'
-    boonVersion = '0.5.7-RC1'
-    //boonGroup = "io.advantageous.boon"
-    boonGroup = "com.github.advantageous"
+    boonVersion = '0.5.7'
+    boonGroup = "io.advantageous.boon"
     springFrameworkVersion = '4.2.5.RELEASE'
     springBootVersion = '1.3.3.RELEASE'
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/Factory.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/Factory.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 /**
  * Main factory for QBit. This gets used internally to create things easily.
@@ -281,7 +282,8 @@ public interface Factory {
             String trustStorePath,
             String trustStorePassword,
             boolean tcpNoDelay,
-            int soLinger
+            int soLinger,
+            Consumer<Throwable> errorHandler
 
     ) {
         return FactorySPI.getHttpClientFactory().create(
@@ -301,7 +303,8 @@ public interface Factory {
                 trustStorePath,
                 trustStorePassword,
                 tcpNoDelay,
-                soLinger
+                soLinger,
+                errorHandler
 
         );
 

--- a/qbit/core/src/main/java/io/advantageous/qbit/QBit.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/QBit.java
@@ -94,7 +94,7 @@ public class QBit {
             });
 
 
-            FactorySPI.setHttpClientFactory((host, port, timeOutInMilliseconds, poolSize, autoFlush, flushRate, keepAlive, pipeLine, ssl, verifyHost, trustAll, maxWebSocketFrameSize, tryUseCompression, trustStorePath, trustStorePassword, tcpNoDelay, soLinger) -> {
+            FactorySPI.setHttpClientFactory((host, port, timeOutInMilliseconds, poolSize, autoFlush, flushRate, keepAlive, pipeLine, ssl, verifyHost, trustAll, maxWebSocketFrameSize, tryUseCompression, trustStorePath, trustStorePassword, tcpNoDelay, soLinger, errorHandler) -> {
                 throw new IllegalStateException("Unable to load Vertx network libs");
             });
         }

--- a/qbit/core/src/main/java/io/advantageous/qbit/http/HttpStatus.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/http/HttpStatus.java
@@ -37,6 +37,10 @@ public class HttpStatus {
     public final static int TOO_MANY_REQUEST = 429;
     public final static String TOO_MANY_REQUEST_MSG = "TOO MANY REQUEST";
 
+
+    public final static int SERVICE_UNAVAILABLE = 503;
+    public final static String SERVICE_UNAVAILABLE_MSG = "Service Unavailable";
+
     public final static String message(int code) {
         switch (code) {
             case OK:
@@ -57,6 +61,8 @@ public class HttpStatus {
                 return ERROR_MSG;
             case ACCEPTED:
                 return ACCEPTED_MSG;
+            case SERVICE_UNAVAILABLE:
+                return SERVICE_UNAVAILABLE_MSG;
             default:
                 return "CODE = " + code;
         }

--- a/qbit/core/src/main/java/io/advantageous/qbit/http/client/HttpClientBuilder.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/http/client/HttpClientBuilder.java
@@ -22,6 +22,7 @@ import io.advantageous.qbit.QBit;
 import io.advantageous.qbit.config.PropertyResolver;
 
 import java.util.Properties;
+import java.util.function.Consumer;
 
 
 /**
@@ -52,6 +53,7 @@ public class HttpClientBuilder {
     private String trustStorePassword;
     private boolean tcpNoDelay = true;
     private int soLinger = 100;
+    private Consumer<Throwable> errorHandler = throwable -> {};
 
 
     public HttpClientBuilder(PropertyResolver propertyResolver) {
@@ -231,16 +233,27 @@ public class HttpClientBuilder {
         return tcpNoDelay;
     }
 
-    public void setTcpNoDelay(boolean tcpNoDelay) {
+    public HttpClientBuilder setTcpNoDelay(boolean tcpNoDelay) {
         this.tcpNoDelay = tcpNoDelay;
+        return this;
     }
 
     public int getSoLinger() {
         return soLinger;
     }
 
-    public void setSoLinger(int soLinger) {
+    public HttpClientBuilder setSoLinger(int soLinger) {
         this.soLinger = soLinger;
+        return this;
+    }
+
+    public Consumer<Throwable> getErrorHandler() {
+        return errorHandler;
+    }
+
+    public HttpClientBuilder setErrorHandler(Consumer<Throwable> errorHandler) {
+        this.errorHandler = errorHandler;
+        return this;
     }
 
     public HttpClient build() {
@@ -262,7 +275,8 @@ public class HttpClientBuilder {
                 this.getTrustStorePath(),
                 this.getTrustStorePassword(),
                 this.isTcpNoDelay(),
-                this.getSoLinger());
+                this.getSoLinger(),
+                this.getErrorHandler());
 
         return httpClient;
     }

--- a/qbit/core/src/main/java/io/advantageous/qbit/spi/HttpClientFactory.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/spi/HttpClientFactory.java
@@ -20,6 +20,8 @@ package io.advantageous.qbit.spi;
 
 import io.advantageous.qbit.http.client.HttpClient;
 
+import java.util.function.Consumer;
+
 /**
  * created by rhightower on 11/13/14.
  */
@@ -35,5 +37,6 @@ public interface HttpClientFactory {
                       String trustStorePath,
                       String trustStorePassword,
                       boolean tcpNoDelay,
-                      int soLinger);
+                      int soLinger,
+                      Consumer<Throwable> errorHandler);
 }

--- a/qbit/core/src/test/java/io/advantageous/qbit/boon/client/BoonClientTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/boon/client/BoonClientTest.java
@@ -59,7 +59,7 @@ public class BoonClientTest {
         });
         FactorySPI.setHttpClientFactory((host, port, timeOutInMilliseconds, poolSize, autoFlush, flushRate, keepAlive,
                                          pipeLine, ssl, verifyHost, trustAll, maxWebSocketFrameSize,
-                                         tryUseCompression, trustStorePath, trustStorePassword, tcpNoDelay, soLinger) ->
+                                         tryUseCompression, trustStorePath, trustStorePassword, tcpNoDelay, soLinger, throwableConsumer) ->
                 new HttpClientMock());
 
 

--- a/qbit/core/src/test/java/io/advantageous/qbit/http/HttpClientBuilderTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/http/HttpClientBuilderTest.java
@@ -27,6 +27,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.function.Consumer;
+
 import static io.advantageous.boon.core.Exceptions.die;
 
 
@@ -55,17 +57,19 @@ public class HttpClientBuilderTest {
                                                String trustStorePath,
                                                String trustStorePassword,
                                                boolean tcpNoDelay,
-                                               int soLinger) {
+                                               int soLinger,
+                                               Consumer<Throwable> throwableConsumer) {
                 return FactorySPI.getHttpClientFactory().create(host, port,
                         timeOutInMilliseconds, poolSize, autoFlush, flushRate, keepAlive, pipeline,
-                        ssl, verifyHost, trustAll, maxWebSocketFrameSize, tryUseCompression, trustStorePath, trustStorePassword, tcpNoDelay, soLinger);
+                        ssl, verifyHost, trustAll, maxWebSocketFrameSize, tryUseCompression, trustStorePath,
+                        trustStorePassword, tcpNoDelay, soLinger, throwableConsumer);
             }
         });
 
         FactorySPI.setHttpClientFactory(
                 (host, port, timeOutInMilliseconds,
                  poolSize, autoFlush, flushRate, keepAlive, pipeLine, ssl, verifyHost, trustAll, maxWebSocketFrameSize,
-                 tryUseCompression, trustStorePath, trustStorePathPassword, tcpNoDelay, soLinger) -> null);
+                 tryUseCompression, trustStorePath, trustStorePathPassword, tcpNoDelay, soLinger, errorHandler) -> null);
 
         Sys.sleep(100);
 

--- a/qbit/core/src/test/java/io/advantageous/qbit/perf/PerfTestMain.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/perf/PerfTestMain.java
@@ -58,7 +58,12 @@ public class PerfTestMain {
 
 
             @Override
-            public HttpClient create(String host, int port, int timeOutInMilliseconds, int poolSize, boolean autoFlush, int flushRate, boolean keepAlive, boolean pipeLine, boolean ssl, boolean verifyHost, boolean trustAll, int maxWebSocketFrameSize, boolean tryUseCompression, String trustStorePath, String trustStorePassword, boolean tcpNoDelay, int soLinger) {
+            public HttpClient create(String host, int port,
+                                     int timeOutInMilliseconds, int poolSize, boolean autoFlush, int flushRate,
+                                     boolean keepAlive, boolean pipeLine, boolean ssl, boolean verifyHost,
+                                     boolean trustAll, int maxWebSocketFrameSize, boolean tryUseCompression,
+                                     String trustStorePath, String trustStorePassword,
+                                     boolean tcpNoDelay, int soLinger, Consumer<Throwable> throwableConsumer) {
                 return new MockHttpClient();
             }
 

--- a/qbit/core/src/test/java/io/advantageous/qbit/service/rest/endpoint/tests/tests/SingleArgumentUserDefinedObjectRESTTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/service/rest/endpoint/tests/tests/SingleArgumentUserDefinedObjectRESTTest.java
@@ -508,7 +508,7 @@ public class SingleArgumentUserDefinedObjectRESTTest {
 
 
     @Test
-    public void echoEmployeeBadString() {
+    public void echoEmployeeNormal() {
         final HttpTextResponse httpResponse = httpServerSimulator.postBodyPlain("/es/echoEmployee",
                 "{\"id\":\"a\",\"name\":\"Rick\"}");
 

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/VertxHttpClientBuilder.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/VertxHttpClientBuilder.java
@@ -56,6 +56,6 @@ public class VertxHttpClientBuilder extends HttpClientBuilder {
                 super.isPipeline(), super.isSsl(), super.isVerifyHost(), super.isTrustAll(),
                 super.getMaxWebSocketFrameSize(), super.isTryUseCompression(), super.getTrustStorePath(),
                 super.getTrustStorePassword(),
-                super.isTcpNoDelay(), super.getSoLinger());
+                super.isTcpNoDelay(), super.getSoLinger(), super.getErrorHandler());
     }
 }

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/client/HttpVertxClient.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/client/HttpVertxClient.java
@@ -22,6 +22,7 @@ import io.advantageous.boon.core.Str;
 import io.advantageous.boon.core.Sys;
 import io.advantageous.boon.primitive.CharBuf;
 import io.advantageous.qbit.GlobalConstants;
+import io.advantageous.qbit.http.HttpStatus;
 import io.advantageous.qbit.http.client.HttpClient;
 import io.advantageous.qbit.http.request.HttpRequest;
 import io.advantageous.qbit.http.request.HttpResponseReceiver;
@@ -230,6 +231,8 @@ public class HttpVertxClient implements HttpClient {
                     logger.warn("Unable to stop client " +
                             "after failed connection", ex);
                 }
+                request.getReceiver().errorWithCode("\"Client connection was closed\"", HttpStatus.SERVICE_UNAVAILABLE);
+                logger.warn("Connection error", error);
             } else {
                 logger.error("Unable to connect to " + host + " port " + port, error);
             }

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/client/HttpVertxClient.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/client/HttpVertxClient.java
@@ -84,6 +84,7 @@ public class HttpVertxClient implements HttpClient {
     private final int soLinger;
     private final boolean autoFlush;
     private final boolean startedVertx;
+    private final Consumer<Throwable> errorHandler;
     protected int poolSize;
     protected io.vertx.core.http.HttpClient httpClient;
     volatile long responseCount = 0;
@@ -111,7 +112,8 @@ public class HttpVertxClient implements HttpClient {
                            final String trustStorePath,
                            final String trustStorePassword,
                            final boolean tcpNoDelay,
-                           final int soLinger) {
+                           final int soLinger,
+                           final Consumer<Throwable> errorHandler) {
 
         this.flushInterval = flushInterval;
         this.port = port;
@@ -133,73 +135,76 @@ public class HttpVertxClient implements HttpClient {
         this.trustStorePassword = trustStorePassword;
         this.tcpNoDelay = tcpNoDelay;
         this.soLinger = soLinger;
+        this.errorHandler = errorHandler;
 
     }
 
-
-    /**
-     * Constructor that allows you to pass a vertx object.
-     *
-     * @param vertx                 vertx
-     * @param host                  host
-     * @param port                  port
-     * @param timeOutInMilliseconds timout milis
-     * @param poolSize              poolsize
-     * @param autoFlush             autoflush
-     * @param flushInterval         flush interval
-     * @param keepAlive             keepAlive
-     * @param pipeline              pipeline enabled
-     * @param ssl                   ssl enabled
-     * @param verifyHost            verify host enabled
-     * @param trustAll              trust all
-     * @param maxWebSocketFrameSize maxWebSocketFrameSize
-     * @param tryUseCompression     tryUseCompression
-     * @param trustStorePath        trustStorePath
-     * @param trustStorePassword    trustStorePassword
-     * @param tcpNoDelay            tcpNoDelay
-     * @param soLinger              soLinger
-     */
-    public HttpVertxClient(final Vertx vertx,
-                           final String host,
-                           final int port,
-                           final int timeOutInMilliseconds,
-                           final int poolSize,
-                           final boolean autoFlush,
-                           final int flushInterval,
-                           final boolean keepAlive,
-                           final boolean pipeline,
-                           final boolean ssl,
-                           final boolean verifyHost,
-                           final boolean trustAll,
-                           final int maxWebSocketFrameSize,
-                           final boolean tryUseCompression,
-                           final String trustStorePath,
-                           final String trustStorePassword,
-                           final boolean tcpNoDelay,
-                           final int soLinger) {
-
-        this.flushInterval = flushInterval;
-        this.port = port;
-        this.host = host;
-        this.timeOutInMilliseconds = timeOutInMilliseconds;
-        this.poolSize = poolSize;
-        this.vertx = vertx;
-        this.startedVertx = false;
-        this.poolSize = poolSize;
-        this.keepAlive = keepAlive;
-        this.pipeline = pipeline;
-        this.autoFlush = autoFlush;
-        this.ssl = ssl;
-        this.verifyHost = verifyHost;
-        this.trustAll = trustAll;
-        this.maxWebSocketFrameSize = maxWebSocketFrameSize;
-        this.tryUseCompression = tryUseCompression;
-        this.trustStorePath = trustStorePath;
-        this.trustStorePassword = trustStorePassword;
-        this.tcpNoDelay = tcpNoDelay;
-        this.soLinger = soLinger;
-
-    }
+//
+//    /**
+//     * Constructor that allows you to pass a vertx object.
+//     *
+//     * @param vertx                 vertx
+//     * @param host                  host
+//     * @param port                  port
+//     * @param timeOutInMilliseconds timout milis
+//     * @param poolSize              poolsize
+//     * @param autoFlush             autoflush
+//     * @param flushInterval         flush interval
+//     * @param keepAlive             keepAlive
+//     * @param pipeline              pipeline enabled
+//     * @param ssl                   ssl enabled
+//     * @param verifyHost            verify host enabled
+//     * @param trustAll              trust all
+//     * @param maxWebSocketFrameSize maxWebSocketFrameSize
+//     * @param tryUseCompression     tryUseCompression
+//     * @param trustStorePath        trustStorePath
+//     * @param trustStorePassword    trustStorePassword
+//     * @param tcpNoDelay            tcpNoDelay
+//     * @param soLinger              soLinger
+//     */
+//    public HttpVertxClient(final Vertx vertx,
+//                           final String host,
+//                           final int port,
+//                           final int timeOutInMilliseconds,
+//                           final int poolSize,
+//                           final boolean autoFlush,
+//                           final int flushInterval,
+//                           final boolean keepAlive,
+//                           final boolean pipeline,
+//                           final boolean ssl,
+//                           final boolean verifyHost,
+//                           final boolean trustAll,
+//                           final int maxWebSocketFrameSize,
+//                           final boolean tryUseCompression,
+//                           final String trustStorePath,
+//                           final String trustStorePassword,
+//                           final boolean tcpNoDelay,
+//                           final int soLinger,
+//                           final Consumer<Throwable> errorHandler) {
+//
+//        this.flushInterval = flushInterval;
+//        this.port = port;
+//        this.host = host;
+//        this.timeOutInMilliseconds = timeOutInMilliseconds;
+//        this.poolSize = poolSize;
+//        this.vertx = vertx;
+//        this.startedVertx = false;
+//        this.poolSize = poolSize;
+//        this.keepAlive = keepAlive;
+//        this.pipeline = pipeline;
+//        this.autoFlush = autoFlush;
+//        this.ssl = ssl;
+//        this.verifyHost = verifyHost;
+//        this.trustAll = trustAll;
+//        this.maxWebSocketFrameSize = maxWebSocketFrameSize;
+//        this.tryUseCompression = tryUseCompression;
+//        this.trustStorePath = trustStorePath;
+//        this.trustStorePassword = trustStorePassword;
+//        this.tcpNoDelay = tcpNoDelay;
+//        this.soLinger = soLinger;
+//        this.errorHandler = errorHandler;
+//
+//    }
 
 
     @Override
@@ -228,6 +233,8 @@ public class HttpVertxClient implements HttpClient {
                 try {
                     stop();
                 } catch (Exception ex) {
+
+                    errorHandler.accept(ex);
                     logger.warn("Unable to stop client " +
                             "after failed connection", ex);
                 }
@@ -236,6 +243,8 @@ public class HttpVertxClient implements HttpClient {
             } else {
                 logger.error("Unable to connect to " + host + " port " + port, error);
             }
+
+            errorHandler.accept(error);
         });
 
         if (headers != null) {
@@ -293,6 +302,7 @@ public class HttpVertxClient implements HttpClient {
                         charBuf.addString(key).add('=').addString(val).add('&');
                     }
                 } catch (UnsupportedEncodingException e) {
+                    errorHandler.accept(e);
                     throw new IllegalStateException(e);
                 }
             }
@@ -331,6 +341,7 @@ public class HttpVertxClient implements HttpClient {
             }
         } catch (Exception ex) {
 
+            errorHandler.accept(ex);
             logger.debug("problem shutting down vertx httpClient for QBIT Http Client", ex);
         }
 
@@ -339,6 +350,7 @@ public class HttpVertxClient implements HttpClient {
                 vertx.close();
 
             } catch (Exception ex) {
+                errorHandler.accept(ex);
                 logger.debug("problem shutting down vertx for QBIT Http Client", ex);
 
             }
@@ -557,6 +569,7 @@ public class HttpVertxClient implements HttpClient {
             try {
                 stop();
             } catch (Exception ex) {
+                errorHandler.accept(ex);
                 logger.warn("Problem closing client in finalize", ex);
             }
         }

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/client/HttpVertxClientFactory.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/client/HttpVertxClientFactory.java
@@ -3,6 +3,8 @@ package io.advantageous.qbit.vertx.http.client;
 import io.advantageous.qbit.http.client.HttpClient;
 import io.advantageous.qbit.spi.HttpClientFactory;
 
+import java.util.function.Consumer;
+
 public class HttpVertxClientFactory implements HttpClientFactory {
     @Override
     public HttpClient create(String host,
@@ -21,9 +23,10 @@ public class HttpVertxClientFactory implements HttpClientFactory {
                              String trustStorePath,
                              String trustStorePassword,
                              boolean tcpNoDelay,
-                             int soLinger) {
+                             int soLinger,
+                             Consumer<Throwable> errorHandler) {
         return new HttpVertxClient(host, port, timeOutInMilliseconds, poolSize, autoFlush,
                 flushRate, keepAlive, pipeLine, ssl, verifyHost, trustAll, maxWebSocketFrameSize,
-                tryUseCompression, trustStorePath, trustStorePassword, tcpNoDelay, soLinger);
+                tryUseCompression, trustStorePath, trustStorePassword, tcpNoDelay, soLinger, errorHandler);
     }
 }

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/HttpServerVertx.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/HttpServerVertx.java
@@ -165,7 +165,7 @@ public class HttpServerVertx implements HttpServer {
     }
 
     @Override
-    public void startWithNotify(Runnable runnable) {
+    public void startWithNotify(final Runnable runnable) {
 
         simpleHttpServer.start();
 
@@ -216,7 +216,7 @@ public class HttpServerVertx implements HttpServer {
                     simpleHttpServer.getErrorHandler().accept(event.cause());
                 } else {
 
-                    runnable.run();
+                    if (runnable!=null) runnable.run();
                     logger.info("HTTP SERVER started on port " + port + " host " + host);
                     simpleHttpServer.getOnStart().run();
                 }

--- a/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/bugs/Bug660.java
+++ b/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/bugs/Bug660.java
@@ -1,0 +1,46 @@
+package io.advantageous.qbit.vertx.bugs;
+
+import io.advantageous.boon.core.Sys;
+import io.advantageous.qbit.http.client.HttpClient;
+import io.advantageous.qbit.http.client.HttpClientBuilder;
+import io.advantageous.qbit.http.request.HttpRequestBuilder;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.advantageous.boon.core.IO.puts;
+import static org.junit.Assert.assertEquals;
+
+public class Bug660 {
+
+    @Test
+    public void test() throws Exception {
+        final HttpClient httpClient = HttpClientBuilder.httpClientBuilder()
+                .setHost("localhost")
+                .setPort(9999)
+                .buildAndStart();
+
+        AtomicInteger codeRef = new AtomicInteger();
+
+
+        httpClient.sendHttpRequest(HttpRequestBuilder
+                .httpRequestBuilder()
+                .setJsonBodyForPost("\"hi mob\"")
+                .setResponse((code, contentType, body) -> {
+                    puts(code, contentType, body);
+                    codeRef.set(code);
+                })
+                .build());
+
+        for (int index = 0; index < 100; index++) {
+            if (codeRef.get()!=0) {
+                break;
+            }
+            Sys.sleep(1);
+        }
+
+        assertEquals(503, codeRef.get());
+
+    }
+
+}

--- a/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/bugs/Bug660.java
+++ b/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/bugs/Bug660.java
@@ -1,26 +1,34 @@
 package io.advantageous.qbit.vertx.bugs;
 
-        import io.advantageous.boon.core.Sys;
-        import io.advantageous.qbit.http.client.HttpClient;
-        import io.advantageous.qbit.http.client.HttpClientBuilder;
-        import io.advantageous.qbit.http.request.HttpRequestBuilder;
-        import org.junit.Test;
+import io.advantageous.boon.core.Sys;
+import io.advantageous.qbit.http.client.HttpClient;
+import io.advantageous.qbit.http.client.HttpClientBuilder;
+import io.advantageous.qbit.http.request.HttpRequestBuilder;
+import org.junit.Test;
 
-        import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
-        import static io.advantageous.boon.core.IO.puts;
-        import static org.junit.Assert.assertEquals;
+import static io.advantageous.boon.core.IO.puts;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class Bug660 {
 
     @Test
     public void test() throws Exception {
-        final HttpClient httpClient = HttpClientBuilder.httpClientBuilder()
-                .setHost("localhost")
-                .setPort(9999)
-                .buildAndStart();
 
         AtomicInteger codeRef = new AtomicInteger();
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+
+        final HttpClient httpClient = HttpClientBuilder.httpClientBuilder()
+                .setHost("localhost")
+                .setPort(9999).setErrorHandler((err) ->
+                        {
+                                error.compareAndSet(null, err);
+                        })
+                .buildAndStart();
 
 
         httpClient.sendHttpRequest(HttpRequestBuilder
@@ -33,13 +41,16 @@ public class Bug660 {
                 .build());
 
         for (int index = 0; index < 100; index++) {
-            if (codeRef.get()!=0) {
+            if (codeRef.get() != 0 && error.get()!=null) {
                 break;
             }
             Sys.sleep(1);
         }
 
         assertEquals(503, codeRef.get());
+
+
+        assertNotNull(error.get());
 
     }
 

--- a/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/bugs/Bug660.java
+++ b/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/bugs/Bug660.java
@@ -1,15 +1,15 @@
 package io.advantageous.qbit.vertx.bugs;
 
-import io.advantageous.boon.core.Sys;
-import io.advantageous.qbit.http.client.HttpClient;
-import io.advantageous.qbit.http.client.HttpClientBuilder;
-import io.advantageous.qbit.http.request.HttpRequestBuilder;
-import org.junit.Test;
+        import io.advantageous.boon.core.Sys;
+        import io.advantageous.qbit.http.client.HttpClient;
+        import io.advantageous.qbit.http.client.HttpClientBuilder;
+        import io.advantageous.qbit.http.request.HttpRequestBuilder;
+        import org.junit.Test;
 
-import java.util.concurrent.atomic.AtomicInteger;
+        import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.advantageous.boon.core.IO.puts;
-import static org.junit.Assert.assertEquals;
+        import static io.advantageous.boon.core.IO.puts;
+        import static org.junit.Assert.assertEquals;
 
 public class Bug660 {
 

--- a/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/http/websocket/WebSocketProxy.java
+++ b/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/http/websocket/WebSocketProxy.java
@@ -6,6 +6,7 @@ import io.advantageous.qbit.reactive.Callback;
 import io.advantageous.qbit.server.EndpointServerBuilder;
 import io.advantageous.qbit.server.ServiceEndpointServer;
 import io.advantageous.qbit.service.ServiceProxyUtils;
+import io.advantageous.qbit.util.PortUtils;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;
@@ -49,11 +50,12 @@ public class WebSocketProxy {
     public void test() throws Exception {
 
 
+        final int port = PortUtils.findOpenPortStartAt(8080);
         final ServiceEndpointServer serviceEndpointServer = EndpointServerBuilder.endpointServerBuilder()
-                .setPort(9999)
+                .setPort(port).setHost("localhost")
                 .addService(new EmployeeServiceImpl()).build().startServerAndWait();
 
-        final Client client = ClientBuilder.clientBuilder().setPort(9999).setHost("localhost").build().startClient();
+        final Client client = ClientBuilder.clientBuilder().setPort(port).setHost("localhost").build().startClient();
 
         final EmployeeService employeeService = client.createProxy(EmployeeService.class, "employeeserviceimpl");
 


### PR DESCRIPTION
Bug 660 fix for HttpClient fast fail on sendHttpRequest.

https://github.com/advantageous/qbit/issues/660

```java
package io.advantageous.qbit.vertx.bugs;

import io.advantageous.boon.core.Sys;
import io.advantageous.qbit.http.client.HttpClient;
import io.advantageous.qbit.http.client.HttpClientBuilder;
import io.advantageous.qbit.http.request.HttpRequestBuilder;
import org.junit.Test;

import java.util.concurrent.atomic.AtomicInteger;

import static io.advantageous.boon.core.IO.puts;
import static org.junit.Assert.assertEquals;

public class Bug660 {

    @Test
    public void test() throws Exception {
        final HttpClient httpClient = HttpClientBuilder.httpClientBuilder()
                .setHost("localhost")
                .setPort(9999)
                .buildAndStart();

        AtomicInteger codeRef = new AtomicInteger();
        httpClient.sendHttpRequest(HttpRequestBuilder
                .httpRequestBuilder()
                .setJsonBodyForPost("\"hi mob\"")
                .setResponse((code, contentType, body) -> {
                    puts(code, contentType, body);
                    codeRef.set(code);
                }).build());

        for (int index = 0; index < 100; index++) {
            if (codeRef.get()!=0) {
                break;
            }
            Sys.sleep(1);
        }
        assertEquals(503, codeRef.get());
    }

}

```

Ok.. I added an error handler so you can get notified of error messages and exceptions directly. 

```java
        final HttpClient httpClient = HttpClientBuilder.httpClientBuilder()
                .setHost("localhost")
                .setPort(9999).setErrorHandler((err) ->
                        {
                                error.compareAndSet(null, err);
                        })
                .buildAndStart();

```

