### PR TITLE
Simulating https://github.com/advantageous/qbit/issues/702

### DIFF
--- a/qbit/core/src/test/java/io/advantageous/qbit/service/rest/endpoint/tests/services/EmployeeServiceSingleObjectTestService.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/service/rest/endpoint/tests/services/EmployeeServiceSingleObjectTestService.java
@@ -185,6 +185,20 @@ public class EmployeeServiceSingleObjectTestService {
         callback.accept(add);
     }
 
+    /**
+     * Like employee-async-ack but with @RequestParam annotated employee param
+     *
+     * @param callback callback
+     * @param employee employee
+     */
+    @RequestMapping(value = "/employee-async-ack-with-request-param", method = RequestMethod.POST)
+    public void addEmployeeAsyncAckWithRequestParam(final Callback<Long> callback,
+                                                    @RequestParam(value = "employee") final Employee employee) {
+        puts(employee);
+        employeeList.add(employee);
+        callback.accept(employee.getId());
+    }
+
 
     @RequestMapping(value = "/throw", method = RequestMethod.POST)
     public void addEmployeeThrowException(final Callback<Boolean> callback,

--- a/qbit/core/src/test/java/io/advantageous/qbit/service/rest/endpoint/tests/tests/SingleArgumentUserDefinedObjectRESTTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/service/rest/endpoint/tests/tests/SingleArgumentUserDefinedObjectRESTTest.java
@@ -545,6 +545,16 @@ public class SingleArgumentUserDefinedObjectRESTTest {
         assertEquals("true", httpResponse.body());
     }
 
+
+    @Test
+    public void addEmployeeUsingCallbackWithRequestParam() {
+        final HttpTextResponse httpResponse = httpServerSimulator.postBody("/es/employee-async-ack-with-request-param",
+                new Employee(1, "Rick"));
+
+        assertEquals(200, httpResponse.code());
+        assertEquals("1", httpResponse.body());
+    }
+
     @Test
     public void addEmployeeThrowException() {
         final HttpTextResponse httpResponse = httpServerSimulator.postBody("/es/throw",


### PR DESCRIPTION
In the EmployeeServiceSingleObjectTestService.java addEmployeeAsyncAck works but addEmployeeAsyncAckWithRequestParam cannot be.