### PR TITLE
Service discovery add host

### DIFF
--- a/qbit/admin/src/main/java/io/advantageous/qbit/metrics/support/StatServiceBuilder.java
+++ b/qbit/admin/src/main/java/io/advantageous/qbit/metrics/support/StatServiceBuilder.java
@@ -311,7 +311,7 @@ public class StatServiceBuilder {
 
 
             serviceDiscovery.registerWithIdAndTimeToLive(this.getServiceName(), localServiceId,
-                    endpointServerBuilder.getPort(), timeToLiveCheckInterval);
+                    endpointServerBuilder.getHost(), endpointServerBuilder.getPort(), timeToLiveCheckInterval);
 
 
         }

--- a/qbit/consul-client/src/main/java/io/advantageous/consul/domain/Service.java
+++ b/qbit/consul-client/src/main/java/io/advantageous/consul/domain/Service.java
@@ -19,7 +19,7 @@ package io.advantageous.consul.domain;
 
 import io.advantageous.boon.json.annotations.JsonProperty;
 
-import java.util.List;
+import java.util.*;
 
 /**
  * Holds service information.
@@ -34,6 +34,9 @@ public class Service {
 
     @JsonProperty("Tags")
     private List<String> tags;
+
+    @JsonProperty("Address")
+    private int host;
 
     @JsonProperty("Port")
     private int port;
@@ -70,6 +73,14 @@ public class Service {
         this.port = port;
     }
 
+    public int getHost() {
+        return host;
+    }
+
+    public void setHost(int host) {
+        this.host = host;
+    }
+
     @SuppressWarnings("SimplifiableIfStatement")
     @Override
     public boolean equals(Object o) {
@@ -79,6 +90,7 @@ public class Service {
         Service service1 = (Service) o;
 
         if (port != service1.port) return false;
+        if (host != service1.host) return false;
         if (id != null ? !id.equals(service1.id) : service1.id != null) return false;
         if (service != null ? !service.equals(service1.service) : service1.service != null) return false;
         return !(tags != null ? !tags.equals(service1.tags) : service1.tags != null);
@@ -91,6 +103,7 @@ public class Service {
         result = 31 * result + (service != null ? service.hashCode() : 0);
         result = 31 * result + (tags != null ? tags.hashCode() : 0);
         result = 31 * result + port;
+        result = 31 * result + host;
         return result;
     }
 
@@ -101,6 +114,7 @@ public class Service {
                 ", service='" + service + '\'' +
                 ", tags=" + tags +
                 ", port=" + port +
+                ", host=" + host +
                 '}';
     }
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/server/EndpointServerBuilder.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/server/EndpointServerBuilder.java
@@ -49,7 +49,7 @@ import io.advantageous.qbit.transforms.Transformer;
 import io.advantageous.qbit.util.Timer;
 
 import java.util.*;
-import java.util.function.Consumer;
+import java.util.function.*;
 
 import static io.advantageous.qbit.http.server.HttpServerBuilder.httpServerBuilder;
 
@@ -66,6 +66,11 @@ public class EndpointServerBuilder {
      * Default URI of main web port.
      */
     public static final int DEFAULT_PORT = 8080;
+
+    /**
+     * Default URI of main web host.
+     */
+    public static final String DEFAULT_HOST = "localhost";
 
     /**
      * Default URI of REST and web socket services.
@@ -92,7 +97,7 @@ public class EndpointServerBuilder {
     /**
      * Name of host we will listen on.
      */
-    private String host;
+    private String host = DEFAULT_HOST;
 
     /**
      * Name of port we will listen on.
@@ -680,7 +685,7 @@ public class EndpointServerBuilder {
                 getEncoder(), getParser(), serviceBundle, getJsonMapper(), this.getTimeoutSeconds(),
                 this.getNumberOfOutstandingRequests(), getProtocolBatchSize(),
                 this.getFlushInterval(), this.getSystemManager(), getEndpointName(), getEndpointId(),
-                getServiceDiscovery(), getPort(), getTtlSeconds(), getHealthService(), getErrorHandler(),
+                getServiceDiscovery(), getHost(), getPort(), getTtlSeconds(), getHealthService(), getErrorHandler(),
                 getFlushResponseInterval(), getParserWorkerCount(), getEncoderWorkerCount());
 
         if (serviceEndpointServer != null && qBitSystemManager != null) {

--- a/qbit/core/src/main/java/io/advantageous/qbit/server/EndpointServerBuilder.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/server/EndpointServerBuilder.java
@@ -89,7 +89,6 @@ public class EndpointServerBuilder {
      */
     private Queue<Response<Object>> responseQueue;
 
-
     /**
      * Name of host we will listen on.
      */
@@ -140,7 +139,6 @@ public class EndpointServerBuilder {
      */
     private QueueBuilder requestQueueBuilder;
 
-
     /**
      * Service (downstream and main) request Queue setup.
      */
@@ -171,7 +169,6 @@ public class EndpointServerBuilder {
      */
     private HealthServiceAsync healthService = null;
 
-
     private StatsCollector statsCollector = null;
     private Timer timer;
     private boolean enableHealthEndpoint;
@@ -184,7 +181,6 @@ public class EndpointServerBuilder {
     private int parserWorkerCount = 4;
     private int encoderWorkerCount = 2;
 
-
     private CallbackManager callbackManager;
     private CallbackManagerBuilder callbackManagerBuilder;
     private HealthServiceBuilder healthServiceBuilder;
@@ -193,6 +189,7 @@ public class EndpointServerBuilder {
     private Map<String, Object> servicesWithAlias;
 
     private String endpointName;
+    private String endpointId;
     private ServiceDiscovery serviceDiscovery;
     private int ttlSeconds;
 
@@ -240,7 +237,6 @@ public class EndpointServerBuilder {
         this.parserWorkerCount = propertyResolver.getIntegerProperty("parserWorkerCount", parserWorkerCount);
         this.flushResponseInterval = propertyResolver.getLongProperty("flushResponseInterval", flushResponseInterval);
         this.protocolBatchSize = propertyResolver.getIntegerProperty("protocolBatchSize", protocolBatchSize);
-
 
     }
 
@@ -338,6 +334,15 @@ public class EndpointServerBuilder {
 
     public EndpointServerBuilder setEndpointName(String endpointName) {
         this.endpointName = endpointName;
+        return this;
+    }
+
+    public String getEndpointId() {
+        return endpointId;
+    }
+
+    public EndpointServerBuilder setEndpointId(String endpointId) {
+        this.endpointId = endpointId;
         return this;
     }
 
@@ -451,7 +456,6 @@ public class EndpointServerBuilder {
         return this;
     }
 
-
     public QueueBuilder getWebResponseQueueBuilder() {
         if (webResponseQueueBuilder == null) {
             webResponseQueueBuilder = QueueBuilder.queueBuilder().setArrayBlockingQueue().setBatchSize(100);
@@ -463,7 +467,6 @@ public class EndpointServerBuilder {
         this.webResponseQueueBuilder = webResponseQueueBuilder;
         return this;
     }
-
 
     public QBitSystemManager getSystemManager() {
         return qBitSystemManager;
@@ -521,7 +524,6 @@ public class EndpointServerBuilder {
         this.invokeDynamic = invokeDynamic;
         return this;
     }
-
 
     public boolean isEachServiceInItsOwnThread() {
         return eachServiceInItsOwnThread;
@@ -605,7 +607,6 @@ public class EndpointServerBuilder {
         return this;
     }
 
-
     public int getFlushInterval() {
         return flushInterval;
     }
@@ -623,7 +624,6 @@ public class EndpointServerBuilder {
                 responseQueueBuilder = QueueBuilder.queueBuilder().setArrayBlockingQueue().setBatchSize(100);
             } else {
 
-
                 responseQueueBuilder = new QueueBuilder() {
 
                     @Override
@@ -633,7 +633,6 @@ public class EndpointServerBuilder {
                     }
                 };
             }
-
 
         }
 
@@ -654,12 +653,9 @@ public class EndpointServerBuilder {
         return this;
     }
 
-
     public ServiceEndpointServer build() {
 
-
         final ServiceBundle serviceBundle;
-
 
         serviceBundle = getFactory().createServiceBundle(uri,
                 getRequestQueueBuilder(),
@@ -680,14 +676,12 @@ public class EndpointServerBuilder {
                 getBeforeMethodCallOnServiceQueue(),
                 getAfterMethodCallOnServiceQueue());
 
-
         final ServiceEndpointServer serviceEndpointServer = new ServiceEndpointServerImpl(getHttpServer(),
                 getEncoder(), getParser(), serviceBundle, getJsonMapper(), this.getTimeoutSeconds(),
                 this.getNumberOfOutstandingRequests(), getProtocolBatchSize(),
-                this.getFlushInterval(), this.getSystemManager(), getEndpointName(),
+                this.getFlushInterval(), this.getSystemManager(), getEndpointName(), getEndpointId(),
                 getServiceDiscovery(), getPort(), getTtlSeconds(), getHealthService(), getErrorHandler(),
                 getFlushResponseInterval(), getParserWorkerCount(), getEncoderWorkerCount());
-
 
         if (serviceEndpointServer != null && qBitSystemManager != null) {
             qBitSystemManager.registerServer(serviceEndpointServer);
@@ -702,7 +696,6 @@ public class EndpointServerBuilder {
         }
         return serviceEndpointServer;
     }
-
 
     public int getStatsFlushRateSeconds() {
         return statsFlushRateSeconds;
@@ -760,14 +753,12 @@ public class EndpointServerBuilder {
         return this;
     }
 
-
     public EndpointServerBuilder addServices(Object... services) {
         for (Object service : services) {
             getServices().add(service);
         }
         return this;
     }
-
 
     public HttpServerBuilder getHttpServerBuilder() {
 
@@ -777,7 +768,6 @@ public class EndpointServerBuilder {
                     .setHost(getHost())
                     .setFlushInterval(this.getFlushInterval())
                     .setSystemManager(getSystemManager());
-
 
             setupHealthAndStats(httpServerBuilder);
 
@@ -791,13 +781,11 @@ public class EndpointServerBuilder {
         return this;
     }
 
-
     public EndpointServerBuilder setupHealthAndStats(final HttpServerBuilder httpServerBuilder) {
 
         if (isEnableStatEndpoint() || isEnableHealthEndpoint()) {
             final boolean healthEnabled = isEnableHealthEndpoint();
             final boolean statsEnabled = isEnableStatEndpoint();
-
 
             final HealthServiceAsync healthServiceAsync = healthEnabled ? getHealthService() : null;
 
@@ -808,10 +796,8 @@ public class EndpointServerBuilder {
                             healthServiceAsync, statCollection));
         }
 
-
         return this;
     }
-
 
     public EventManager getEventManager() {
         return eventManager;

--- a/qbit/core/src/main/java/io/advantageous/qbit/server/ServiceEndpointServerImpl.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/server/ServiceEndpointServerImpl.java
@@ -43,10 +43,9 @@ import io.advantageous.qbit.util.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
+import java.util.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
 
 /**
  * Implementation of a service endpoint server.  This is the server that exposes a set of qbit services to the network.
@@ -85,6 +84,7 @@ public class ServiceEndpointServerImpl implements ServiceEndpointServer {
                                      final String endpointName,
                                      final String endpointId,
                                      final ServiceDiscovery serviceDiscovery,
+                                     final String host,
                                      final int port,
                                      final int ttlSeconds,
                                      final HealthServiceAsync healthServiceAsync,
@@ -114,19 +114,19 @@ public class ServiceEndpointServerImpl implements ServiceEndpointServer {
                 new HttpRequestServiceServerHandlerUsingMetaImpl(this.timeoutInSeconds,
                         serviceBundle, jsonMapper, numberOfOutstandingRequests, flushInterval, errorHandler);
 
-        this.endpoint = createEndpoint(endpointName, endpointId, port, ttlSeconds);
+        this.endpoint = createEndpoint(endpointName, endpointId, host, port, ttlSeconds);
 
     }
 
-    private EndpointDefinition createEndpoint(String endpointName, String endpointId, int port, int ttlSeconds) {
+    private EndpointDefinition createEndpoint(String endpointName, String endpointId, String host, int port, int ttlSeconds) {
         if (serviceDiscovery != null) {
             if (ttlSeconds > 0) {
                 if (endpointId != null) {
-                    return serviceDiscovery.registerWithIdAndTimeToLive(endpointName, endpointId, port, ttlSeconds);
+                    return serviceDiscovery.registerWithIdAndTimeToLive(endpointName, endpointId, host, port, ttlSeconds);
                 }
-                return serviceDiscovery.registerWithTTL(endpointName, port, ttlSeconds);
+                return serviceDiscovery.registerWithTTL(endpointName, host, port, ttlSeconds);
             } else {
-                return serviceDiscovery.register(endpointName, port);
+                return serviceDiscovery.register(endpointName, host, port);
             }
         }
         return null;

--- a/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/ServiceDiscovery.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/ServiceDiscovery.java
@@ -7,17 +7,13 @@ import io.advantageous.qbit.service.health.HealthStatus;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 /**
  * Service Discovery
  * created by rhightower on 3/23/15.
  */
 public interface ServiceDiscovery extends Startable, Stoppable {
-
 
     /**
      * Generates a unique string, used for generating unique service ids
@@ -37,16 +33,18 @@ public interface ServiceDiscovery extends Startable, Stoppable {
      * Register the service with the service discovery service if applicable.
      *
      * @param serviceName serviceName
+     * @param host        host
      * @param port        port
      * @return EndpointDefinition
      */
     default EndpointDefinition register(
             final String serviceName,
+            final String host,
             final int port) {
 
         return new EndpointDefinition(HealthStatus.PASS,
                 serviceName + "." + uniqueString(port),
-                serviceName, null, port);
+                serviceName, host, port);
     }
 
     /**
@@ -55,12 +53,14 @@ public interface ServiceDiscovery extends Startable, Stoppable {
      * TTL is time to live.
      *
      * @param serviceName       service name
+     * @param host              host
      * @param port              port
      * @param timeToLiveSeconds ttl
      * @return EndpointDefinition
      */
     default EndpointDefinition registerWithTTL(
             final String serviceName,
+            final String host,
             final int port,
             final int timeToLiveSeconds) {
 
@@ -75,17 +75,18 @@ public interface ServiceDiscovery extends Startable, Stoppable {
      *
      * @param serviceName       service name
      * @param serviceId         service id
+     * @param host              host
      * @param port              port
      * @param timeToLiveSeconds ttl
      * @return EndpointDefinition
      */
     @SuppressWarnings("UnusedReturnValue")
     default EndpointDefinition registerWithIdAndTimeToLive(
-            final String serviceName, final String serviceId, final int port, final int timeToLiveSeconds) {
+            final String serviceName, final String serviceId, String host, final int port, final int timeToLiveSeconds) {
 
         return new EndpointDefinition(HealthStatus.PASS,
                 serviceId,
-                serviceName, null, port, timeToLiveSeconds);
+                serviceName, host, port, timeToLiveSeconds);
     }
 
     /**
@@ -93,16 +94,16 @@ public interface ServiceDiscovery extends Startable, Stoppable {
      *
      * @param serviceName service name
      * @param serviceId   service id
+     * @param host        host
      * @param port        port
      * @return EndpointDefinition
      */
-    default EndpointDefinition registerWithId(final String serviceName, final String serviceId, final int port) {
+    default EndpointDefinition registerWithId(final String serviceName, final String serviceId, String host, final int port) {
 
         return new EndpointDefinition(HealthStatus.PASS,
                 serviceId,
-                serviceName, null, port);
+                serviceName, host, port);
     }
-
 
     /**
      * Watch for changes in this service name and send change events if the service changes.
@@ -123,7 +124,6 @@ public interface ServiceDiscovery extends Startable, Stoppable {
     default void checkIn(String serviceId, HealthStatus healthStatus) {
 
     }
-
 
     /**
      * This is like `checkIn` but does an HealthStatus.SUCCESS if applicable.
@@ -163,7 +163,6 @@ public interface ServiceDiscovery extends Startable, Stoppable {
 
     }
 
-
     /**
      * See `loadServices` this is like `loadServices` except it forces a remote call.
      * This is a blocking call to loadServices.
@@ -187,7 +186,6 @@ public interface ServiceDiscovery extends Startable, Stoppable {
      */
     default void stop() {
     }
-
 
     /**
      * This just loads the end points that were registered locally.

--- a/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/impl/ServiceDiscoveryImpl.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/impl/ServiceDiscoveryImpl.java
@@ -149,11 +149,11 @@ public class ServiceDiscoveryImpl implements ServiceDiscovery {
     }
 
     @Override
-    public EndpointDefinition register(final String serviceName, final int port) {
+    public EndpointDefinition register(final String serviceName, String host, final int port) {
 
         if (trace) {
             logger.trace(
-                    "ServiceDiscoveryImpl::register()" + serviceName + " " + port
+                    "ServiceDiscoveryImpl::register()" + serviceName + " " + host + ":" + port
             );
         }
 
@@ -162,18 +162,18 @@ public class ServiceDiscoveryImpl implements ServiceDiscovery {
 
         EndpointDefinition endpointDefinition = new EndpointDefinition(HealthStatus.PASS,
                 serviceName + "-" + ServiceDiscovery.uniqueString(port),
-                serviceName, null, port);
+                serviceName, host, port);
 
         return doRegister(endpointDefinition);
 
     }
 
     @Override
-    public EndpointDefinition registerWithId(final String serviceName, final String serviceId, final int port) {
+    public EndpointDefinition registerWithId(final String serviceName, final String serviceId, String host, final int port) {
 
         if (trace) {
             logger.trace(
-                    "ServiceDiscoveryImpl::registerWithId()" + serviceName + " " + port
+                    "ServiceDiscoveryImpl::registerWithId()" + serviceName + " " + host + ":" + port
             );
         }
 
@@ -182,7 +182,7 @@ public class ServiceDiscoveryImpl implements ServiceDiscovery {
 
         EndpointDefinition endpointDefinition = new EndpointDefinition(HealthStatus.PASS,
                 serviceId,
-                serviceName, null, port);
+                serviceName, host, port);
 
         return doRegister(endpointDefinition);
 

--- a/qbit/core/src/test/java/io/advantageous/qbit/server/ServerTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/server/ServerTest.java
@@ -32,13 +32,13 @@ import io.advantageous.qbit.spi.ProtocolParser;
 import io.advantageous.qbit.test.TimedTesting;
 import org.junit.Test;
 
-import java.util.*;
-import java.util.concurrent.atomic.*;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.advantageous.boon.core.Exceptions.die;
 import static io.advantageous.boon.core.IO.puts;
 import static io.advantageous.boon.json.JsonFactory.fromJsonArray;
-import static io.advantageous.consul.domain.ConsulException.die;
 
 public class ServerTest extends TimedTesting {
 

--- a/qbit/core/src/test/java/io/advantageous/qbit/server/ServerTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/server/ServerTest.java
@@ -32,9 +32,8 @@ import io.advantageous.qbit.spi.ProtocolParser;
 import io.advantageous.qbit.test.TimedTesting;
 import org.junit.Test;
 
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.*;
+import java.util.concurrent.atomic.*;
 
 import static io.advantageous.boon.core.Exceptions.die;
 import static io.advantageous.boon.core.IO.puts;
@@ -42,10 +41,8 @@ import static io.advantageous.boon.json.JsonFactory.fromJsonArray;
 
 public class ServerTest extends TimedTesting {
 
-
     @Test
     public void testServer() {
-
 
         super.setupLatch();
 
@@ -57,12 +54,10 @@ public class ServerTest extends TimedTesting {
 
         JsonMapper mapper = new BoonJsonMapper();
 
-
         ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder,
-                parser, serviceBundle, mapper, 30, 100, 30, 10, null, null, null, 8080, 0, null, null, 50, 2, 2);
+                parser, serviceBundle, mapper, 30, 100, 30, 10, null, null, null, null, 8080, 0, null, null, 50, 2, 2);
 
         server.initServices(Sets.set(new TodoService()));
-
 
         final AtomicBoolean resultsWorked = new AtomicBoolean();
 
@@ -70,16 +65,13 @@ public class ServerTest extends TimedTesting {
 
         httpServer.postRequestObject("/services/todo-manager/todo", new Todo("Call Dad", "Call Dad", new Date()), (code, mimeType, body) -> {
 
-
             puts("CALL CALLED", body, "\n\n");
             if (body != null && code == 202 && body.equals("\"success\"")) {
                 resultsWorked.set(true);
             }
         });
 
-
         waitForTrigger(20, o -> resultsWorked.get());
-
 
         if (!resultsWorked.get()) {
             die("Add operation did not work");
@@ -90,7 +82,6 @@ public class ServerTest extends TimedTesting {
         httpServer.sendHttpGet("/services/todo-manager/todo/list/", null, (code, mimeType, body) -> {
 
             puts("ADD CALL RESPONSE code ", code, " mimeType ", mimeType, " body ", body);
-
 
             List<Todo> todos = fromJsonArray(body, Todo.class);
             if (todos.size() > 0) {
@@ -106,7 +97,6 @@ public class ServerTest extends TimedTesting {
         server.flush();
         Sys.sleep(100);
 
-
         waitForTrigger(20, o -> resultsWorked.get());
 
         if (!resultsWorked.get()) {
@@ -115,22 +105,19 @@ public class ServerTest extends TimedTesting {
 
     }
 
-
     @Test
     public void testServerTimeout() {
 
         ProtocolEncoder encoder = QBit.factory().createEncoder();
         MockHttpServer httpServer = new MockHttpServer();
 
-
         final ServiceBundle serviceBundle = new ServiceBundleBuilder().setAddress("/services").build();
         JsonMapper mapper = new BoonJsonMapper();
-
 
         ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder,
                 QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30,
                 10, null,
-                null, null, 8080, 0, null, null, 50, 2, 2);
+                null, null, null, 8080, 0, null, null, 50, 2, 2);
 
         server.initServices(Sets.set(new TodoService()));
 
@@ -142,13 +129,11 @@ public class ServerTest extends TimedTesting {
 
             httpServer.sendHttpGet("/services/todo-manager/timeout", null, (code, mimeType, body) -> {
 
-
                 if (code == 408 && body != null && body.equals("\"timed out\"")) {
                     resultsWorked.set(true);
                 }
             });
         }
-
 
         server.serviceBundle().flushSends();
         Sys.sleep(100);
@@ -156,9 +141,7 @@ public class ServerTest extends TimedTesting {
         server.flush();
         Sys.sleep(100);
 
-
         waitForTrigger(8, o -> resultsWorked.get());
-
 
         if (!resultsWorked.get()) {
             die(" we did not get timeout");
@@ -167,7 +150,6 @@ public class ServerTest extends TimedTesting {
         resultsWorked.set(false);
 
     }
-
 
     @Test
     public void testNoMethodCallFound() {
@@ -179,10 +161,9 @@ public class ServerTest extends TimedTesting {
 
         JsonMapper mapper = new BoonJsonMapper();
 
-
         ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(
                 httpServer, encoder, QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30, 10,
-                null, null, null, 8080, 0, null, null, 50, 2, 2);
+                null, null, null, null, 8080, 0, null, null, 50, 2, 2);
 
         server.initServices(new TodoService());
 
@@ -190,17 +171,14 @@ public class ServerTest extends TimedTesting {
 
         final AtomicBoolean resultsWorked = new AtomicBoolean();
 
-
         resultsWorked.set(false);
 
         httpServer.sendHttpGet("/services/todo-manager/testNoMethodCallFound", null, (code, mimeType, body) -> {
-
 
             if (code == 404) {
                 resultsWorked.set(true);
             }
         });
-
 
         server.serviceBundle().flushSends();
         Sys.sleep(100);
@@ -208,9 +186,7 @@ public class ServerTest extends TimedTesting {
         server.flush();
         Sys.sleep(100);
 
-
         waitForTrigger(20, o -> resultsWorked.get());
-
 
         if (!resultsWorked.get()) {
             die(" we did not get timeout");

--- a/qbit/core/src/test/java/io/advantageous/qbit/server/ServerTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/server/ServerTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.*;
 import static io.advantageous.boon.core.Exceptions.die;
 import static io.advantageous.boon.core.IO.puts;
 import static io.advantageous.boon.json.JsonFactory.fromJsonArray;
+import static io.advantageous.consul.domain.ConsulException.die;
 
 public class ServerTest extends TimedTesting {
 
@@ -55,7 +56,7 @@ public class ServerTest extends TimedTesting {
         JsonMapper mapper = new BoonJsonMapper();
 
         ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder,
-                parser, serviceBundle, mapper, 30, 100, 30, 10, null, null, null, null, 8080, 0, null, null, 50, 2, 2);
+                parser, serviceBundle, mapper, 30, 100, 30, 10, null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
 
         server.initServices(Sets.set(new TodoService()));
 
@@ -117,7 +118,7 @@ public class ServerTest extends TimedTesting {
         ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder,
                 QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30,
                 10, null,
-                null, null, null, 8080, 0, null, null, 50, 2, 2);
+                null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
 
         server.initServices(Sets.set(new TodoService()));
 
@@ -163,7 +164,7 @@ public class ServerTest extends TimedTesting {
 
         ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(
                 httpServer, encoder, QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30, 10,
-                null, null, null, null, 8080, 0, null, null, 50, 2, 2);
+                null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
 
         server.initServices(new TodoService());
 

--- a/qbit/core/src/test/java/io/advantageous/qbit/server/ServiceEndpointServerImplTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/server/ServiceEndpointServerImplTest.java
@@ -48,10 +48,11 @@ import io.advantageous.qbit.test.TimedTesting;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
+import java.util.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
 
+import static com.sun.xml.internal.ws.dump.LoggingDumpTube.Position.Before;
 import static io.advantageous.boon.core.Exceptions.die;
 import static io.advantageous.boon.core.IO.puts;
 import static io.advantageous.qbit.service.ServiceBuilder.serviceBuilder;
@@ -76,14 +77,12 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
         final ProtocolParser protocolParser = factory.createProtocolParser();
         final ProtocolEncoder encoder = factory.createEncoder();
 
-
         final ServiceBundle serviceBundle = new ServiceBundleBuilder().setAddress("/services").build();
         final JsonMapper mapper = factory.createJsonMapper();
 
-
         httpServer = new HttpServerMock();
-        serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle, mapper, 1, 100, 30, 10, null, "", null, 8080, 0, null, null, 50, 2, 2);
-
+        serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle, mapper, 1, 100, 30, 10, null, "",
+                "", null, 8080, 0, null, null, 50, 2, 2);
 
         callMeCounter = 0;
         responseCounter = 0;
@@ -91,7 +90,6 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
         serviceServerImpl.start();
 
         Sys.sleep(500);
-
 
     }
 
@@ -102,38 +100,31 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
         final ProtocolParser protocolParser = factory.createProtocolParser();
         final ProtocolEncoder encoder = factory.createEncoder();
 
-
         final Queue<Response<Object>> responseQueue = QueueBuilder.queueBuilder().setName("RESPONSE QUEUE TEST").build();
 
         final ServiceBundle serviceBundle = new ServiceBundleBuilder()
                 .setResponseQueue(responseQueue).setAddress("/services").build();
         final JsonMapper mapper = factory.createJsonMapper();
 
-
         httpServer = new HttpServerMock();
         serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle,
-                mapper, 1, 100, 30, 10, null, null, null, 8080, 0, null, null, 50, 2, 2);
-
+                mapper, 1, 100, 30, 10, null, null, null, null, 8080, 0, null, null, 50, 2, 2);
 
         callMeCounter = 0;
         responseCounter = 0;
-
 
         ServiceQueue serviceQueue = serviceBuilder()
                 .setResponseQueue(responseQueue)
                 .setServiceObject(new MyOtherService()).buildAndStart();
 
-
         serviceServerImpl.addServiceQueue("/services/other/serviceCall", serviceQueue);
 
         serviceServerImpl.start();
-
 
         final HttpRequest request = new HttpRequestBuilder().setUri("/services/other/servicecall")
                 .setTextReceiver(new MockReceiver()).setBody("\"call\"").build();
 
         httpServer.sendRequest(request);
-
 
         Sys.sleep(100);
 
@@ -151,32 +142,26 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
         final ProtocolParser protocolParser = factory.createProtocolParser();
         final ProtocolEncoder encoder = factory.createEncoder();
 
-
         final Queue<Response<Object>> responseQueue = QueueBuilder.queueBuilder().setName("RESPONSE QUEUE").build();
 
         final ServiceBundle serviceBundle = new ServiceBundleBuilder()
                 .setResponseQueue(responseQueue).setAddress("/services").build();
         final JsonMapper mapper = factory.createJsonMapper();
 
-
         httpServer = new HttpServerMock();
         serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle,
-                mapper, 1, 100, 30, 10, null, null, null, 8080, 0, null, null, 50, 2, 2);
-
+                mapper, 1, 100, 30, 10, null, null, null, null, 8080, 0, null, null, 50, 2, 2);
 
         callMeCounter = 0;
         responseCounter = 0;
-
 
         ServiceQueue serviceQueue = serviceBuilder()
                 .setResponseQueue(responseQueue)
                 .setServiceObject(new MyOtherService()).buildAndStart();
 
-
         serviceServerImpl.addServiceQueue("other", serviceQueue);
 
         serviceServerImpl.start();
-
 
         final MethodCall<Object> methodCall = new MethodCallBuilder().setObjectName("other").setName("method").setBody(null).build();
 
@@ -185,9 +170,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
         httpServer.sendWebSocketServerMessage(new WebSocketMessageBuilder().setRemoteAddress("/foo")
                 .setMessage(message).setSender(new MockWebSocketSender()).build());
 
-
         Sys.sleep(100);
-
 
         waitForTrigger(20, o -> responseCounter == 1);
 
@@ -205,7 +188,6 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         httpServer.sendRequest(request);
 
-
         Sys.sleep(10);
         serviceServerImpl.flush();
         Sys.sleep(10);
@@ -214,7 +196,6 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         ok |= responseCounter == 1 || die();
         ok |= callMeCounter == 1 || die();
-
 
     }
 
@@ -228,14 +209,11 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         httpServer.sendRequest(request);
 
-
         waitForTrigger(20, o -> timeOutCounter.get() >= 1);
-
 
         ok |= responseCounter == 0 || die();
         ok |= callMeCounter == 0 || die();
         ok |= timeOutCounter.get() >= 1 || die(); //TODO fix
-
 
     }
 
@@ -254,17 +232,14 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         Sys.sleep(10);
 
-
         waitForTrigger(20, o -> responseCounter == 1 && callMeCounter == 1);
 
         Sys.sleep(10);
-
 
         ok |= responseCounter == 1 || die();
         ok |= callMeCounter == 1 || die();
 
         ok |= lastResponse.equals("\"baconPOST\"") || die();
-
 
     }
 
@@ -275,12 +250,12 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
         responseCounter = 0;
         callMeCounter = 0;
 
-        final HttpRequest request = new HttpRequestBuilder().setUri("/services/mock/callPost").setTextReceiver(new MockReceiver()).setBody("[]").build();
+        final HttpRequest request = new HttpRequestBuilder().setUri("/services/mock/callPost").setTextReceiver(new MockReceiver()).setBody("[]")
+                .build();
 
         httpServer.sendRequest(request);
 
         waitForTrigger(20, o -> failureCounter == 1);
-
 
         ok |= failureCounter == 1 || die();
         ok |= callMeCounter == 0 || die();
@@ -302,31 +277,25 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         Sys.sleep(10);
 
-
         waitForTrigger(20, o -> responseCounter == 1 && callMeCounter == 1);
-
 
         ok |= responseCounter == 1 || die();
         ok |= callMeCounter == 1 || die();
         ok |= lastResponse.equals("\"bacon\"") || die();
-
 
     }
 
     @Test
     public void testWeSocketCallThatIsCrap() throws Exception {
 
-
         httpServer.sendWebSocketServerMessage(new WebSocketMessageBuilder().setMessage("CRAP")
 
                 .setRemoteAddress("/crap/at/crap").setSender(new MockWebSocketSender()).build());
-
 
         Sys.sleep(10);
         serviceServerImpl.flush();
 
         Sys.sleep(10);
-
 
         waitForTrigger(20, o -> responseCounter == 1 && failureCounter == 1);
 
@@ -338,20 +307,19 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
     @Test
     public void testWebSocketCall() throws Exception {
 
-        final MethodCall<Object> methodCall = new MethodCallBuilder().setObjectName("serviceMockObject").setName("callWithReturn").setBody(null).build();
+        final MethodCall<Object> methodCall = new MethodCallBuilder().setObjectName("serviceMockObject").setName("callWithReturn").setBody(null)
+                .build();
 
         final String message = QBit.factory().createEncoder().encodeMethodCalls("", Lists.list(methodCall));
 
-        httpServer.sendWebSocketServerMessage(new WebSocketMessageBuilder().setRemoteAddress("/foo").setMessage(message).setSender(new MockWebSocketSender()).build());
-
+        httpServer.sendWebSocketServerMessage(new WebSocketMessageBuilder().setRemoteAddress("/foo").setMessage(message).setSender(new
+                MockWebSocketSender()).build());
 
         Sys.sleep(10);
-
 
         serviceServerImpl.flush();
 
         Sys.sleep(10);
-
 
         waitForTrigger(20, o -> responseCounter == 1);
 
@@ -365,17 +333,16 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
     @Test
     public void testExceptionCall() throws Exception {
 
-        final HttpRequest request = new HttpRequestBuilder().setUri("/services/mock/exceptionCall").setTextReceiver(new MockReceiver()).setBody("").build();
+        final HttpRequest request = new HttpRequestBuilder().setUri("/services/mock/exceptionCall").setTextReceiver(new MockReceiver()).setBody("")
+                .build();
 
         httpServer.sendRequest(request);
 
         Sys.sleep(10);
 
-
         serviceServerImpl.flush();
 
         Sys.sleep(10);
-
 
         waitForTrigger(20, o -> callMeCounter == 1 && failureCounter == 1);
 
@@ -383,7 +350,6 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
         ok |= callMeCounter == 1 || die();
 
         puts(lastResponse);
-
 
     }
 
@@ -395,16 +361,14 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         final String message = QBit.factory().createEncoder().encodeMethodCalls("", Lists.list(methodCall));
 
-        httpServer.sendWebSocketServerMessage(new WebSocketMessageBuilder().setRemoteAddress("/error").setMessage(message).setSender(new MockWebSocketSender()).build());
-
+        httpServer.sendWebSocketServerMessage(new WebSocketMessageBuilder().setRemoteAddress("/error").setMessage(message).setSender(new
+                MockWebSocketSender()).build());
 
         Sys.sleep(5);
-
 
         serviceServerImpl.flush();
 
         Sys.sleep(5);
-
 
         waitForTrigger(20, o -> callMeCounter == 1 && failureCounter == 1);
         ok |= failureCounter == 1 || die();
@@ -437,13 +401,11 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
         @RequestMapping("/timeOut")
         public String timeOut() {
 
-
             puts("TIMEOUT");
             Sys.sleep(30000);
 
             return "ok";
         }
-
 
         @RequestMapping("/callWithReturn")
         public String callWithReturn() {
@@ -456,7 +418,6 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
             callMeCounter++;
             return "baconPOST";
         }
-
 
         @RequestMapping("/exceptionCall")
         public String exceptionCall() {
@@ -496,7 +457,6 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
             if (messages.size() == 1) {
 
-
                 responseCounter++;
                 final Response<Object> response = (Response<Object>) messages.get(0);
                 if (response.wasErrors()) {
@@ -510,7 +470,6 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
         public void sendBytes(byte[] message) {
             //Binary not supported yet
         }
-
 
     }
 
@@ -539,7 +498,6 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
                 while (true) {
                     Sys.sleep(10);
 
-
                     idleConsumerRequest.accept(null);
                     idleConsumerWebSocket.accept(null);
                 }
@@ -557,13 +515,11 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         }
 
-
         public void sendRequest(HttpRequest request) {
 
             requestConsumer.accept(request);
             idleConsumerRequest.accept(null);
         }
-
 
         @Override
         public void setWebSocketMessageConsumer(Consumer<WebSocketMessage> webSocketMessageConsumer) {

--- a/qbit/core/src/test/java/io/advantageous/qbit/server/ServiceEndpointServerImplTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/server/ServiceEndpointServerImplTest.java
@@ -82,7 +82,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         httpServer = new HttpServerMock();
         serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle, mapper, 1, 100, 30, 10, null, "",
-                "", null, 8080, 0, null, null, 50, 2, 2);
+                "", null, "localhost", 8080, 0, null, null, 50, 2, 2);
 
         callMeCounter = 0;
         responseCounter = 0;
@@ -108,7 +108,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         httpServer = new HttpServerMock();
         serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle,
-                mapper, 1, 100, 30, 10, null, null, null, null, 8080, 0, null, null, 50, 2, 2);
+                mapper, 1, 100, 30, 10, null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
 
         callMeCounter = 0;
         responseCounter = 0;
@@ -150,7 +150,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         httpServer = new HttpServerMock();
         serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle,
-                mapper, 1, 100, 30, 10, null, null, null, null, 8080, 0, null, null, 50, 2, 2);
+                mapper, 1, 100, 30, 10, null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
 
         callMeCounter = 0;
         responseCounter = 0;

--- a/qbit/core/src/test/java/io/advantageous/qbit/server/ServiceEndpointServerImplTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/server/ServiceEndpointServerImplTest.java
@@ -48,11 +48,10 @@ import io.advantageous.qbit.test.TimedTesting;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.*;
-import java.util.concurrent.atomic.*;
-import java.util.function.*;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
-import static com.sun.xml.internal.ws.dump.LoggingDumpTube.Position.Before;
 import static io.advantageous.boon.core.Exceptions.die;
 import static io.advantageous.boon.core.IO.puts;
 import static io.advantageous.qbit.service.ServiceBuilder.serviceBuilder;

--- a/qbit/core/src/test/java/io/advantageous/qbit/service/discovery/impl/ServiceDiscoveryImplTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/service/discovery/impl/ServiceDiscoveryImplTest.java
@@ -145,7 +145,7 @@ public class ServiceDiscoveryImplTest {
 
     @Test
     public void testRegisterService() throws Exception {
-        serviceDiscovery.register("fooBar", 9090);
+        serviceDiscovery.register("fooBar", "localhost", 9090);
 
 
         AtomicReference<EndpointDefinition> serviceDefinitionAtomicReference = new AtomicReference<>();
@@ -171,7 +171,7 @@ public class ServiceDiscoveryImplTest {
     @Test
     public void testHealthCheckIn() throws Exception {
 
-        final EndpointDefinition endpointDefinition = serviceDiscovery.register("fooBar", 9090);
+        final EndpointDefinition endpointDefinition = serviceDiscovery.register("fooBar", "localhost", 9090);
 
         serviceDiscovery.checkIn(endpointDefinition.getId(), HealthStatus.PASS);
 

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/HttpServerVertx.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/HttpServerVertx.java
@@ -102,7 +102,7 @@ public class HttpServerVertx implements HttpServer {
         this.startedVertx = startedVertx;
 
         this.simpleHttpServer = new SimpleHttpServer(endpointName, systemManager,
-                options.getFlushInterval(), options.getPort(), serviceDiscovery,
+                options.getFlushInterval(), options.getHost(), options.getPort(), serviceDiscovery,
                 healthServiceAsync, serviceDiscoveryTtl, serviceDiscoveryTtlTimeUnit,
                 decorators, httpResponseCreator, requestBodyContinuePredicate);
         this.vertx = vertx;

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/SimpleVertxHttpServerWrapper.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/SimpleVertxHttpServerWrapper.java
@@ -23,12 +23,9 @@ import io.vertx.ext.web.Router;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.function.*;
 
 public class SimpleVertxHttpServerWrapper implements HttpServer {
 
@@ -51,7 +48,6 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
      */
     private volatile int closeCount;
 
-
     public SimpleVertxHttpServerWrapper(
             final io.vertx.core.http.HttpServer httpServer,
             final Router router,
@@ -72,7 +68,7 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
         this.route = route;
         this.vertx = vertx;
         this.simpleHttpServer = new SimpleHttpServer(endpointName, systemManager,
-                flushInterval, 0, serviceDiscovery,
+                flushInterval, "localhost", 0, serviceDiscovery,
                 healthServiceAsync, serviceDiscoveryTtl, serviceDiscoveryTtlTimeUnit,
                 decorators, httpResponseCreator, requestBodyContinuePredicate);
         this.systemManager = systemManager;
@@ -83,7 +79,6 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
 
         this.httpServer = httpServer;
     }
-
 
     @Override
     public void setShouldContinueHttpRequest(final Predicate<HttpRequest> shouldContinueHttpRequest) {
@@ -115,7 +110,6 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
         );
     }
 
-
     @Override
     public void setWebSocketIdleConsume(final Consumer<Void> idleWebSocketConsumer) {
         this.simpleHttpServer.setWebSocketIdleConsume(
@@ -135,9 +129,7 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
             vertx.setPeriodic(10_000, event -> logger.info("Exception Count {} Close Count {}", exceptionCount, closeCount));
         }
 
-
         httpServer.websocketHandler(this::handleWebSocketMessage);
-
 
         if (route != null) {
             route.handler(event -> handleHttpRequest(event.request(), event.data()));
@@ -147,9 +139,7 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
             httpServer.requestHandler(this::handleHttpRequest);
         }
 
-
     }
-
 
     @Override
     public void stop() {
@@ -157,13 +147,11 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
         if (systemManager != null) systemManager.serviceShutDown();
     }
 
-
     private void handleHttpRequest(final HttpServerRequest request) {
         handleHttpRequest(request, new HashMap<>());
     }
 
     private void handleHttpRequest(final HttpServerRequest request, final Map<String, Object> data) {
-
 
         if (debug) {
             setupMetrics(request);
@@ -194,7 +182,6 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
 
                 break;
 
-
             case "HEAD":
             case "OPTIONS":
             case "DELETE":
@@ -212,7 +199,6 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
 
     }
 
-
     private void setupMetrics(final HttpServerRequest request) {
 
         request.exceptionHandler(event -> {
@@ -227,11 +213,9 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
 
         request.endHandler(event -> {
 
-
             if (debug) {
                 closeCount++;
             }
-
 
             logger.info("REQUEST OVER");
         });
@@ -241,11 +225,9 @@ public class SimpleVertxHttpServerWrapper implements HttpServer {
         simpleHttpServer.handleOpenWebSocket(vertxUtils.createWebSocket(webSocket));
     }
 
-
     @Override
     public void setWebSocketOnOpenConsumer(Consumer<WebSocket> onOpenConsumer) {
         this.simpleHttpServer.setWebSocketOnOpenConsumer(onOpenConsumer);
     }
-
 
 }


### PR DESCRIPTION
Currently it is not possible to set a host in service discovery, which is mandatory to connect to a remote instance. This pull request bind the host parameter to service discovery and allow to retrieve it in ServiceHealth response from Consul. It also add the availability to pass endpointId parameter which is missing for service discovery