### PR TITLE
Add tags service discovery

### DIFF
--- a/qbit/consul-client/src/main/java/io/advantageous/consul/discovery/spi/ConsulServiceDiscoveryProvider.java
+++ b/qbit/consul-client/src/main/java/io/advantageous/consul/discovery/spi/ConsulServiceDiscoveryProvider.java
@@ -95,7 +95,7 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
                 String[] tags = endPointTags != null ? endPointTags.toArray(new String[endPointTags.size()]) : this.tags;
 
                 registrations.put(endpointDefinition.getId(), endpointDefinition);
-                consul.agent().registerService(endpointDefinition.getPort(),
+                consul.agent().registerService(endpointDefinition.getHost(), endpointDefinition.getPort(),
                         endpointDefinition.getTimeToLive(),
                         endpointDefinition.getName(), endpointDefinition.getId(), tags);
                 endpointDefinition = registerQueue.poll();
@@ -139,7 +139,7 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
             if (endpointDefinition != null) {
                 List<String> endPointTags = endpointDefinition.getTags();
                 String[] tags = endPointTags != null ? endPointTags.toArray(new String[endPointTags.size()]) : this.tags;
-                consul.agent().registerService(endpointDefinition.getPort(),
+                consul.agent().registerService(endpointDefinition.getHost(), endpointDefinition.getPort(),
                         endpointDefinition.getTimeToLive(),
                         endpointDefinition.getName(), endpointDefinition.getId(), tags);
             }

--- a/qbit/consul-client/src/main/java/io/advantageous/consul/discovery/spi/ConsulServiceDiscoveryProvider.java
+++ b/qbit/consul-client/src/main/java/io/advantageous/consul/discovery/spi/ConsulServiceDiscoveryProvider.java
@@ -91,6 +91,9 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
         if (endpointDefinition != null) {
             final Consul consul = consul();
             while (endpointDefinition != null) {
+                List<String> endPointTags = endpointDefinition.getTags();
+                String[] tags = endPointTags != null ? endPointTags.toArray(new String[endPointTags.size()]) : this.tags;
+
                 registrations.put(endpointDefinition.getId(), endpointDefinition);
                 consul.agent().registerService(endpointDefinition.getPort(),
                         endpointDefinition.getTimeToLive(),
@@ -134,6 +137,8 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
         } catch (NotRegisteredException notRegisteredException) {
             final EndpointDefinition endpointDefinition = registrations.get(checkIn.getServiceId());
             if (endpointDefinition != null) {
+                List<String> endPointTags = endpointDefinition.getTags();
+                String[] tags = endPointTags != null ? endPointTags.toArray(new String[endPointTags.size()]) : this.tags;
                 consul.agent().registerService(endpointDefinition.getPort(),
                         endpointDefinition.getTimeToLive(),
                         endpointDefinition.getName(), endpointDefinition.getId(), tags);

--- a/qbit/consul-client/src/main/java/io/advantageous/consul/discovery/spi/ConsulServiceDiscoveryProvider.java
+++ b/qbit/consul-client/src/main/java/io/advantageous/consul/discovery/spi/ConsulServiceDiscoveryProvider.java
@@ -18,11 +18,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
 
 import static io.advantageous.boon.core.Str.sputs;
-
 
 /**
  * Consul Service Discovery Provider
@@ -41,7 +40,6 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
     private final AtomicInteger lastIndex = new AtomicInteger();
 
     private final Map<String, EndpointDefinition> registrations = new ConcurrentHashMap<>();
-
 
     public ConsulServiceDiscoveryProvider(final String consulHost,
                                           final int consulPort,
@@ -67,10 +65,8 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
         }
     }
 
-
     @Override
     public void unregisterServices(final ConcurrentHashSet<EndpointDefinition> endpointDefinitions) {
-
 
         for (EndpointDefinition definition : endpointDefinitions) {
             Consul consul = consul();
@@ -79,12 +75,10 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
 
         }
 
-
     }
 
     @Override
     public void registerServices(final Queue<EndpointDefinition> registerQueue) {
-
 
         if (trace) {
             logger.trace(sputs(
@@ -150,7 +144,6 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
 
     private Set<ServiceHealthCheckIn> createUniqueSetOfCheckins(final Queue<ServiceHealthCheckIn> checkInsQueue) {
 
-
         ServiceHealthCheckIn poll = checkInsQueue.poll();
 
         if (poll == null) {
@@ -167,7 +160,6 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
         return set;
     }
 
-
     @Override
     public List<EndpointDefinition> loadServices(final String serviceName) {
 
@@ -178,20 +170,16 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
             ));
         }
 
-
         if (debug) logger.debug(sputs("Fetching healthy nodes for", serviceName));
 
         final List<ServiceHealth> healthyServices = getHealthyServices(serviceName);
 
-
         if (debug) logger.debug(sputs("Fetched healthy nodes for", serviceName,
                 "node count fetched", healthyServices.size()));
-
 
         return convertToServiceDefinitions(healthyServices);
 
     }
-
 
     private List<EndpointDefinition> convertToServiceDefinitions(
             final List<ServiceHealth> healthyServices) {
@@ -208,13 +196,13 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
     }
 
     private EndpointDefinition convertToServiceDefinition(final ServiceHealth serviceHealth) {
-
         final String host = serviceHealth.getNode().getAddress();
         final int port = serviceHealth.getService().getPort();
         final String id = serviceHealth.getService().getId();
         final String name = serviceHealth.getService().getService();
+        final List<String> tags = serviceHealth.getService().getTags();
         final EndpointDefinition endpointDefinition =
-                new EndpointDefinition(HealthStatus.PASS, id, name, host, port);
+                new EndpointDefinition(HealthStatus.PASS, id, name, host, port, tags);
 
         if (debug) logger.debug(sputs("convertToServiceDefinition \nserviceHealth",
                 serviceHealth, "\nserviceDefinition", endpointDefinition));
@@ -222,13 +210,11 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
         return endpointDefinition;
     }
 
-
     private RequestOptions buildRequestOptions() {
         return new RequestOptionsBuilder()
                 .consistency(Consistency.CONSISTENT)
                 .blockSeconds(longPollTimeSeconds, lastIndex.get()).build();
     }
-
 
     private List<ServiceHealth> getHealthyServices(final String serviceName) {
         Consul consul = consul();
@@ -237,7 +223,6 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
         final ConsulResponse<List<ServiceHealth>> consulResponse = consul.health()
                 .getHealthyServices(serviceName, datacenter, tag, buildRequestOptions());
 
-
         this.lastIndex.set(consulResponse.getIndex());
 
         //noinspection UnnecessaryLocalVariable
@@ -245,9 +230,7 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
 
         return healthyServices;
 
-
     }
-
 
     private Status convertStatus(final HealthStatus healthStatus) {
         switch (healthStatus) {
@@ -265,10 +248,8 @@ public class ConsulServiceDiscoveryProvider implements ServiceDiscoveryProvider 
 
     }
 
-
     private Consul consul() {
-        final Consul consul = Consul.consul(consulHost, consulPort);
-        return consul;
+        return Consul.consul(consulHost, consulPort);
     }
 
 }

--- a/qbit/consul-client/src/main/java/io/advantageous/consul/domain/Registration.java
+++ b/qbit/consul-client/src/main/java/io/advantageous/consul/domain/Registration.java
@@ -17,10 +17,9 @@
  */
 package io.advantageous.consul.domain;
 
-
 import io.advantageous.boon.json.annotations.JsonProperty;
 
-import java.util.Arrays;
+import java.util.*;
 
 public class Registration {
 
@@ -29,6 +28,9 @@ public class Registration {
 
     @JsonProperty("Id")
     private String id;
+
+    @JsonProperty("Address")
+    private String host;
 
     @JsonProperty("Port")
     private int port;
@@ -55,6 +57,14 @@ public class Registration {
         this.id = id;
     }
 
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
     public int getPort() {
         return port;
     }
@@ -79,7 +89,6 @@ public class Registration {
         this.tags = tags;
     }
 
-
     @SuppressWarnings("SimplifiableIfStatement")
     @Override
     public boolean equals(Object o) {
@@ -89,6 +98,7 @@ public class Registration {
         Registration that = (Registration) o;
 
         if (port != that.port) return false;
+        if (host != null ? !host.equals(that.host) : that.host != null) return false;
         if (check != null ? !check.equals(that.check) : that.check != null) return false;
         if (id != null ? !id.equals(that.id) : that.id != null) return false;
         return !(name != null ? !name.equals(that.name) : that.name != null) && Arrays.equals(tags, that.tags);
@@ -100,6 +110,7 @@ public class Registration {
         int result = name != null ? name.hashCode() : 0;
         result = 31 * result + (id != null ? id.hashCode() : 0);
         result = 31 * result + port;
+        result = 31 * result + (host != null ? host.hashCode() : 0);
         result = 31 * result + (check != null ? check.hashCode() : 0);
         result = 31 * result + (tags != null ? Arrays.hashCode(tags) : 0);
         return result;
@@ -110,11 +121,11 @@ public class Registration {
         return "Registration{" +
                 "name='" + name + '\'' +
                 ", id='" + id + '\'' +
+                ", host=" + host +
                 ", port=" + port +
                 ", check=" + check +
                 ", tags=" + Arrays.toString(tags) +
                 '}';
     }
-
 
 }

--- a/qbit/consul-client/src/main/java/io/advantageous/consul/endpoints/AgentEndpoint.java
+++ b/qbit/consul-client/src/main/java/io/advantageous/consul/endpoints/AgentEndpoint.java
@@ -22,17 +22,24 @@ package io.advantageous.consul.endpoints;
 import io.advantageous.boon.core.Str;
 import io.advantageous.boon.json.JsonParserAndMapper;
 import io.advantageous.boon.json.JsonParserFactory;
-import io.advantageous.consul.domain.*;
+import io.advantageous.consul.domain.AgentInfo;
+import io.advantageous.consul.domain.Check;
+import io.advantageous.consul.domain.HealthCheck;
+import io.advantageous.consul.domain.Member;
+import io.advantageous.consul.domain.NotRegisteredException;
+import io.advantageous.consul.domain.Registration;
+import io.advantageous.consul.domain.RegistrationCheck;
+import io.advantageous.consul.domain.Service;
+import io.advantageous.consul.domain.Status;
 import io.advantageous.qbit.http.HTTP;
 
 import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static io.advantageous.boon.core.reflection.MapObjectConversion.fromMap;
-import static io.advantageous.boon.json.JsonFactory.*;
+import static io.advantageous.boon.json.JsonFactory.fromJson;
+import static io.advantageous.boon.json.JsonFactory.fromJsonArray;
+import static io.advantageous.boon.json.JsonFactory.toJson;
 import static io.advantageous.consul.domain.ConsulException.die;
 import static io.advantageous.consul.domain.NotRegisteredException.notRegistered;
 
@@ -48,7 +55,6 @@ import static io.advantageous.consul.domain.NotRegisteredException.notRegistered
  */
 @SuppressWarnings("WeakerAccess")
 public class AgentEndpoint extends Endpoint {
-
 
     public AgentEndpoint(String scheme, String host, String port, String rootPath) {
         super(scheme, host, port, rootPath);
@@ -82,7 +88,6 @@ public class AgentEndpoint extends Endpoint {
         }
     }
 
-
     /**
      * Registers the client as a service with Consul.  Registration enables
      * the use of checks.
@@ -96,9 +101,26 @@ public class AgentEndpoint extends Endpoint {
     public void registerService(final int port, final long ttl,
                                 final String serviceName, final String serviceId,
                                 final String... tags) {
+        registerService(null, port, ttl, serviceName, serviceId, tags);
+    }
+
+    /**
+     * Registers the client as a service with Consul.  Registration enables
+     * the use of checks.
+     *
+     * @param host        The public facing host of the service to register with Consul.
+     * @param port        The public facing port of the service to register with Consul.
+     * @param ttl         Time to live for the Consul dead man's switch.
+     * @param serviceName Service name to register.
+     * @param serviceId   Service id to register.
+     * @param tags        Tags to register with.
+     */
+    public void registerService(final String host, final int port, final long ttl,
+                                final String serviceName, final String serviceId,
+                                final String... tags) {
         RegistrationCheck check = new RegistrationCheck();
         check.setTtl("" + ttl + "s");
-        registerServiceWithRegistrationCheck(port, check, serviceName, serviceId, tags);
+        registerServiceWithRegistrationCheck(host, port, check, serviceName, serviceId, tags);
     }
 
     /**
@@ -119,10 +141,33 @@ public class AgentEndpoint extends Endpoint {
                                           final String serviceName,
                                           final String serviceId,
                                           final String... tags) {
+        registerServiceWithScript(null, port, script, interval, serviceName, serviceId, tags);
+    }
+
+    /**
+     * Registers the client as a service with Consul.
+     * Registration enables
+     * the use of check with a script.
+     *
+     * @param host        The public facing host of the service to register with Consul.
+     * @param port        The public facing port of the service to register with Consul.
+     * @param script      Health script for Consul to use.
+     * @param interval    Health script run interval in seconds.
+     * @param serviceName Service name to register.
+     * @param serviceId   Service id to register.
+     * @param tags        Tags to register with.
+     */
+    public void registerServiceWithScript(final String host,
+                                          final int port,
+                                          final String script,
+                                          final long interval,
+                                          final String serviceName,
+                                          final String serviceId,
+                                          final String... tags) {
         RegistrationCheck check = new RegistrationCheck();
         check.setScript(script);
         check.setInterval("" + interval + "s");
-        registerServiceWithRegistrationCheck(port, check, serviceName, serviceId, tags);
+        registerServiceWithRegistrationCheck(host, port, check, serviceName, serviceId, tags);
     }
 
     /**
@@ -135,8 +180,9 @@ public class AgentEndpoint extends Endpoint {
      * @param id    Service id to register.
      * @param tags  Tags to register with.
      */
-    public void registerServiceWithRegistrationCheck(int port, RegistrationCheck check, String name, String id, String... tags) {
+    public void registerServiceWithRegistrationCheck(String host, int port, RegistrationCheck check, String name, String id, String... tags) {
         Registration registration = new Registration();
+        registration.setHost(host);
         registration.setPort(port);
         registration.setCheck(check);
         registration.setName(name);
@@ -151,7 +197,6 @@ public class AgentEndpoint extends Endpoint {
      * @param registration The registration payload.
      */
     public void register(final Registration registration) {
-
 
         final URI uri = createURI("/service/register");
         HTTP.Response response = HTTP.jsonRestCallViaPUT(uri.toString(), toJson(registration));
@@ -247,9 +292,7 @@ public class AgentEndpoint extends Endpoint {
      */
     public void registerCheck(Check check) {
 
-
         final URI uri = createURI("/check/register");
-
 
         HTTP.Response response = HTTP.jsonRestCallViaPUT(uri.toString(), toJson(check));
 
@@ -269,7 +312,6 @@ public class AgentEndpoint extends Endpoint {
 
         final URI uri = createURI("/check/deregister/" + checkId);
 
-
         HTTP.Response response = HTTP.getResponse(uri.toString());
 
         if (response.status() != 200) {
@@ -277,7 +319,6 @@ public class AgentEndpoint extends Endpoint {
                     uri, checkId, response.status(), response.statusMessageAsString(),
                     response.payloadAsString());
         }
-
 
     }
 
@@ -293,7 +334,6 @@ public class AgentEndpoint extends Endpoint {
 
         final URI uri = createURI("/self");
 
-
         HTTP.Response response = HTTP.getResponse(uri.toString());
 
         if (response.status() != 200) {
@@ -301,7 +341,6 @@ public class AgentEndpoint extends Endpoint {
                     uri, response.status(), response.statusMessageAsString(),
                     response.payloadAsString());
         }
-
 
         return fromJson(response.payloadAsString(), AgentInfo.class);
 
@@ -317,7 +356,6 @@ public class AgentEndpoint extends Endpoint {
     public Map<String, HealthCheck> getChecks() {
 
         final URI uri = createURI("/checks");
-
 
         final HTTP.Response response = HTTP.getResponse(uri.toString());
 
@@ -346,12 +384,9 @@ public class AgentEndpoint extends Endpoint {
      */
     public Map<String, Service> getServices() {
 
-
         final URI uri = createURI("/services");
 
-
         final HTTP.Response response = HTTP.getResponse(uri.toString());
-
 
         final JsonParserAndMapper jsonParserAndMapper = new JsonParserFactory().create();
         if (response.status() == 200) {
@@ -397,7 +432,6 @@ public class AgentEndpoint extends Endpoint {
      */
     public void forceLeave(String node) {
 
-
         final URI uri = createURI("/force-leave/" + node);
         final HTTP.Response httpResponse = HTTP.getResponse(uri.toString());
 
@@ -415,9 +449,7 @@ public class AgentEndpoint extends Endpoint {
      */
     public void check(String checkId, Status status, String note) {
 
-
         final URI uri = createURI("/check/" + status.getUri() + "/" + checkId);
-
 
         final HTTP.Response httpResponse = Str.isEmpty(note) ? HTTP.getResponse(uri.toString()) :
                 HTTP.getResponse(uri.toString() + "?note=" + note);

--- a/qbit/consul-client/src/test/java/io/advantageous/consul/AgentEndpointTest.java
+++ b/qbit/consul-client/src/test/java/io/advantageous/consul/AgentEndpointTest.java
@@ -25,11 +25,8 @@ import io.advantageous.consul.domain.ServiceHealth;
 import org.junit.Test;
 
 import java.net.UnknownHostException;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
+import java.util.*;
+import java.util.stream.*;
 
 import static org.junit.Assert.*;
 
@@ -38,14 +35,13 @@ import static org.junit.Assert.*;
  */
 public class AgentEndpointTest {
 
-
     @Test
     public void deregister() throws Exception {
         Consul client = Consul.consul();
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
-        client.agent().registerService(8080, 10000L, serviceName, serviceId);
+        client.agent().registerService("localhost", 8080, 10000L, serviceName, serviceId);
         client.agent().deregister(serviceId);
         Thread.sleep(1000L);
         boolean found = false;
@@ -63,7 +59,7 @@ public class AgentEndpointTest {
     public void checks() {
         Consul client = Consul.consul();
         String id = UUID.randomUUID().toString();
-        client.agent().registerService(8080, 20L, UUID.randomUUID().toString(), id);
+        client.agent().registerService("localhost", 8080, 20L, UUID.randomUUID().toString(), id);
 
         boolean found = false;
 
@@ -80,7 +76,7 @@ public class AgentEndpointTest {
     public void services() {
         Consul client = Consul.consul();
         String id = UUID.randomUUID().toString();
-        client.agent().registerService(8080, 20L, UUID.randomUUID().toString(), id);
+        client.agent().registerService("localhost", 8080, 20L, UUID.randomUUID().toString(), id);
 
         boolean found = false;
 
@@ -99,7 +95,7 @@ public class AgentEndpointTest {
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
         String note = UUID.randomUUID().toString();
-        client.agent().registerService(80, 20L, serviceName, serviceId);
+        client.agent().registerService("localhost", 80, 20L, serviceName, serviceId);
         client.agent().warn(serviceId, note);
         Sys.sleep(100);
         verifyState("warning", client, serviceId, serviceName);
@@ -112,7 +108,7 @@ public class AgentEndpointTest {
         String serviceId = UUID.randomUUID().toString();
         String note = UUID.randomUUID().toString();
 
-        client.agent().registerService(80, 20L, serviceName, serviceId);
+        client.agent().registerService("localhost", 80, 20L, serviceName, serviceId);
         client.agent().fail(serviceId, note);
 
         verifyState("critical", client, serviceId, serviceName);
@@ -140,7 +136,6 @@ public class AgentEndpointTest {
         assertTrue(found);
     }
 
-
     @Test
     public void retrieveAgentInformation() throws UnknownHostException {
         Consul client = Consul.consul();
@@ -158,7 +153,7 @@ public class AgentEndpointTest {
         String serviceName = UUID.randomUUID().toString();
         String serviceId = UUID.randomUUID().toString();
 
-        client.agent().registerService(80, 20000L, serviceName, serviceId);
+        client.agent().registerService("localhost", 80, 20000L, serviceName, serviceId);
 
         boolean found = false;
 
@@ -167,7 +162,6 @@ public class AgentEndpointTest {
                 found = true;
             }
         }
-
 
         assertTrue(found);
     }

--- a/qbit/core/src/main/java/io/advantageous/qbit/server/EndpointServerBuilder.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/server/EndpointServerBuilder.java
@@ -195,6 +195,7 @@ public class EndpointServerBuilder {
 
     private String endpointName;
     private String endpointId;
+    private List<String> endpointTags;
     private ServiceDiscovery serviceDiscovery;
     private int ttlSeconds;
 
@@ -684,7 +685,7 @@ public class EndpointServerBuilder {
         final ServiceEndpointServer serviceEndpointServer = new ServiceEndpointServerImpl(getHttpServer(),
                 getEncoder(), getParser(), serviceBundle, getJsonMapper(), this.getTimeoutSeconds(),
                 this.getNumberOfOutstandingRequests(), getProtocolBatchSize(),
-                this.getFlushInterval(), this.getSystemManager(), getEndpointName(), getEndpointId(),
+                this.getFlushInterval(), this.getSystemManager(), getEndpointName(), getEndpointId(), getEndpointTags(),
                 getServiceDiscovery(), getHost(), getPort(), getTtlSeconds(), getHealthService(), getErrorHandler(),
                 getFlushResponseInterval(), getParserWorkerCount(), getEncoderWorkerCount());
 
@@ -873,6 +874,15 @@ public class EndpointServerBuilder {
 
     public EndpointServerBuilder setProtocolBatchSize(int protocolBatchSize) {
         this.protocolBatchSize = protocolBatchSize;
+        return this;
+    }
+
+    public List<String> getEndpointTags() {
+        return endpointTags;
+    }
+
+    public EndpointServerBuilder setEndpointTags(List<String> endpointTags) {
+        this.endpointTags = endpointTags;
         return this;
     }
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/server/ServiceEndpointServerImpl.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/server/ServiceEndpointServerImpl.java
@@ -83,6 +83,7 @@ public class ServiceEndpointServerImpl implements ServiceEndpointServer {
                                      final QBitSystemManager systemManager,
                                      final String endpointName,
                                      final String endpointId,
+                                     final List<String> endpointTags,
                                      final ServiceDiscovery serviceDiscovery,
                                      final String host,
                                      final int port,
@@ -114,14 +115,18 @@ public class ServiceEndpointServerImpl implements ServiceEndpointServer {
                 new HttpRequestServiceServerHandlerUsingMetaImpl(this.timeoutInSeconds,
                         serviceBundle, jsonMapper, numberOfOutstandingRequests, flushInterval, errorHandler);
 
-        this.endpoint = createEndpoint(endpointName, endpointId, host, port, ttlSeconds);
+        this.endpoint = createEndpoint(endpointName, endpointId, endpointTags, host, port, ttlSeconds);
 
     }
 
-    private EndpointDefinition createEndpoint(String endpointName, String endpointId, String host, int port, int ttlSeconds) {
+    private EndpointDefinition createEndpoint(String endpointName, String endpointId, List<String> endpointTags, String host, int port, int
+            ttlSeconds) {
         if (serviceDiscovery != null) {
             if (ttlSeconds > 0) {
                 if (endpointId != null) {
+                    if (endpointTags != null) {
+                        return serviceDiscovery.registerWithIdAndTTLAndTags(endpointName, endpointId, host, port, ttlSeconds, endpointTags);
+                    }
                     return serviceDiscovery.registerWithIdAndTimeToLive(endpointName, endpointId, host, port, ttlSeconds);
                 }
                 return serviceDiscovery.registerWithTTL(endpointName, host, port, ttlSeconds);

--- a/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/EndpointDefinition.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/EndpointDefinition.java
@@ -6,7 +6,7 @@ import io.advantageous.qbit.service.health.HealthStatus;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.List;
+import java.util.*;
 
 import static io.advantageous.qbit.service.discovery.ServiceDiscovery.uniqueString;
 
@@ -24,7 +24,6 @@ import static io.advantageous.qbit.service.discovery.ServiceDiscovery.uniqueStri
  * created by rhightower on 3/23/15.
  */
 public class EndpointDefinition {
-
 
     /**
      * Current health status.
@@ -52,11 +51,62 @@ public class EndpointDefinition {
     private final int port;
 
     /**
+     * Tags of the service.
+     */
+    private final List<String> tags;
+
+    /**
      * Time to live: how long until this service has to check in with the remote service discovery
      * system if applicable. Whether this is used or needed depends on the underlying service discovery system.
      */
     private final long timeToLive;
 
+    /**
+     * Create a new one with default TTL of 20 seconds with tags.
+     *
+     * @param healthStatus healthStatus
+     * @param id           id
+     * @param name         name
+     * @param host         post
+     * @param port         port
+     * @param tags         tags
+     */
+    public EndpointDefinition(
+            final HealthStatus healthStatus,
+            final String id,
+            final String name,
+            final String host,
+            final int port,
+            final long timeToLive,
+            final List<String> tags) {
+        this.healthStatus = healthStatus;
+        this.id = id;
+        this.name = name;
+        this.host = host;
+        this.port = port;
+        this.timeToLive = timeToLive;
+        this.tags = tags;
+    }
+
+    /**
+     * Create a new one with default TTL of 20 seconds.
+     *
+     * @param healthStatus healthStatus
+     * @param id           id
+     * @param name         name
+     * @param host         post
+     * @param port         port
+     * @param tags         tags
+     */
+    public EndpointDefinition(
+            final HealthStatus healthStatus,
+            final String id,
+            final String name,
+            final String host,
+            final int port,
+            final List<String> tags) {
+        this(healthStatus, id, name, host, port, Sys.sysProp(EndpointDefinition.class.getName() + ".timeToLive", 20L), tags);
+    }
 
     /**
      * Create a new one with default TTL of 20 seconds.
@@ -73,14 +123,8 @@ public class EndpointDefinition {
             final String name,
             final String host,
             final int port) {
-        this.healthStatus = healthStatus;
-        this.id = id;
-        this.name = name;
-        this.host = host;
-        this.port = port;
-        this.timeToLive = Sys.sysProp(EndpointDefinition.class.getName() + ".timeToLive", 20L);
+        this(healthStatus, id, name, host, port, Sys.sysProp(EndpointDefinition.class.getName() + ".timeToLive", 20L), null);
     }
-
 
     /**
      * Create a new one with default TTL of 20 seconds.
@@ -93,12 +137,7 @@ public class EndpointDefinition {
             final String name,
             final String host,
             final int port) {
-        this.healthStatus = HealthStatus.PASS;
-        this.id = name + "-" + port + "-" + host.replace('.', '-');
-        this.name = name;
-        this.host = host;
-        this.port = port;
-        this.timeToLive = Sys.sysProp(EndpointDefinition.class.getName() + ".timeToLive", 20L);
+        this(HealthStatus.PASS, name + "-" + port + "-" + host.replace('.', '-'), name, host, port);
     }
 
     /**
@@ -118,12 +157,7 @@ public class EndpointDefinition {
             final String host,
             final int port,
             final long timeToLive) {
-        this.healthStatus = healthStatus;
-        this.id = id;
-        this.name = name;
-        this.host = host;
-        this.port = port;
-        this.timeToLive = timeToLive;
+        this(healthStatus, id, name, host, port, timeToLive, null);
     }
 
     /**
@@ -210,7 +244,6 @@ public class EndpointDefinition {
                 name + "-" + uniqueString(port), name, host, port);
     }
 
-
     /**
      * Creates a EndpointDefinition for a service, i.e., a serviceDefinition.
      *
@@ -226,7 +259,6 @@ public class EndpointDefinition {
         return new EndpointDefinition(HealthStatus.PASS,
                 name + "-" + uniqueString(0), name, host, 0);
     }
-
 
     /**
      * Creates a EndpointDefinition for a service, i.e., a serviceDefinition.
@@ -265,6 +297,10 @@ public class EndpointDefinition {
         return port;
     }
 
+    public List<String> getTags() {
+        return tags;
+    }
+
     @SuppressWarnings("SimplifiableIfStatement")
     @Override
     public boolean equals(Object o) {
@@ -299,11 +335,12 @@ public class EndpointDefinition {
                 ", name='" + name + '\'' +
                 ", host='" + host + '\'' +
                 ", port=" + port +
+                ", tags=" + port +
                 '}';
     }
 
     public long getTimeToLive() {
-
         return timeToLive;
     }
+
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/EndpointDefinition.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/EndpointDefinition.java
@@ -230,6 +230,27 @@ public class EndpointDefinition {
     /**
      * Creates a EndpointDefinition for a service, i.e., a serviceDefinition.
      *
+     * @param id   id
+     * @param name name
+     * @param host host
+     * @param port port
+     * @param tags tags
+     * @return EndpointDefinition
+     */
+    public static EndpointDefinition serviceDefinition(
+            final String id,
+            final String name,
+            final String host,
+            final int port,
+            List<String> tags) {
+
+        return new EndpointDefinition(HealthStatus.PASS,
+                id, name, host, port, tags);
+    }
+
+    /**
+     * Creates a EndpointDefinition for a service, i.e., a serviceDefinition.
+     *
      * @param name name
      * @param host host
      * @param port port
@@ -335,7 +356,7 @@ public class EndpointDefinition {
                 ", name='" + name + '\'' +
                 ", host='" + host + '\'' +
                 ", port=" + port +
-                ", tags=" + port +
+                ", tags=" + tags +
                 '}';
     }
 

--- a/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/ServiceDiscovery.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/ServiceDiscovery.java
@@ -106,6 +106,24 @@ public interface ServiceDiscovery extends Startable, Stoppable {
     }
 
     /**
+     * Register an end point given an id, and a TTL with tags.
+     * This gets used if you want to be specific about what you call the service.
+     *
+     * @param serviceName       service name
+     * @param serviceId         service id
+     * @param host              host
+     * @param port              port
+     * @param timeToLiveSeconds ttl
+     * @param endpointTags      endpointTags
+     * @return EndpointDefinition
+     */
+    @SuppressWarnings("UnusedReturnValue")
+    default EndpointDefinition registerWithIdAndTTLAndTags(String serviceName, String serviceId, String host, int port, int timeToLiveSeconds,
+                                                           List<String> endpointTags) {
+        return new EndpointDefinition(HealthStatus.PASS, serviceId, serviceName, host, port, timeToLiveSeconds, endpointTags);
+    }
+
+    /**
      * Watch for changes in this service name and send change events if the service changes.
      *
      * @param serviceName serviceName
@@ -196,4 +214,5 @@ public interface ServiceDiscovery extends Startable, Stoppable {
     default Set<EndpointDefinition> localDefinitions() {
         return Collections.emptySet();
     }
+
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/impl/ServiceDiscoveryImpl.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/impl/ServiceDiscoveryImpl.java
@@ -135,6 +135,24 @@ public class ServiceDiscoveryImpl implements ServiceDiscovery {
         return doRegister(endpointDefinition);
     }
 
+    @Override
+    public EndpointDefinition registerWithIdAndTTLAndTags(
+            final String serviceName, final String serviceId, String host, final int port, final int timeToLiveSeconds, List<String> tags) {
+
+        if (trace) {
+            logger.trace(
+                    "ServiceDiscoveryImpl::registerWithIdAndTimeToLive() " + serviceName + " " + port
+            );
+        }
+
+        watch(serviceName);
+        EndpointDefinition endpointDefinition = new EndpointDefinition(HealthStatus.PASS,
+                serviceId,
+                serviceName, host, port, timeToLiveSeconds, tags);
+
+        return doRegister(endpointDefinition);
+    }
+
     private EndpointDefinition doRegister(EndpointDefinition endpointDefinition) {
 
         endpointDefinitions.add(endpointDefinition);

--- a/qbit/core/src/test/java/io/advantageous/qbit/server/ServerTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/server/ServerTest.java
@@ -56,7 +56,7 @@ public class ServerTest extends TimedTesting {
         JsonMapper mapper = new BoonJsonMapper();
 
         ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder,
-                parser, serviceBundle, mapper, 30, 100, 30, 10, null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
+                parser, serviceBundle, mapper, 30, 100, 30, 10, null, null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
 
         server.initServices(Sets.set(new TodoService()));
 
@@ -118,7 +118,7 @@ public class ServerTest extends TimedTesting {
         ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(httpServer, encoder,
                 QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30,
                 10, null,
-                null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
+                null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
 
         server.initServices(Sets.set(new TodoService()));
 
@@ -164,7 +164,7 @@ public class ServerTest extends TimedTesting {
 
         ServiceEndpointServerImpl server = new ServiceEndpointServerImpl(
                 httpServer, encoder, QBit.factory().createProtocolParser(), serviceBundle, mapper, 1, 100, 30, 10,
-                null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
+                null, null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
 
         server.initServices(new TodoService());
 

--- a/qbit/core/src/test/java/io/advantageous/qbit/server/ServiceEndpointServerImplTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/server/ServiceEndpointServerImplTest.java
@@ -48,9 +48,9 @@ import io.advantageous.qbit.test.TimedTesting;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
+import java.util.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
 
 import static io.advantageous.boon.core.Exceptions.die;
 import static io.advantageous.boon.core.IO.puts;
@@ -81,7 +81,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         httpServer = new HttpServerMock();
         serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle, mapper, 1, 100, 30, 10, null, "",
-                "", null, "localhost", 8080, 0, null, null, 50, 2, 2);
+                "", null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
 
         callMeCounter = 0;
         responseCounter = 0;
@@ -107,7 +107,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         httpServer = new HttpServerMock();
         serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle,
-                mapper, 1, 100, 30, 10, null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
+                mapper, 1, 100, 30, 10, null, null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
 
         callMeCounter = 0;
         responseCounter = 0;
@@ -149,7 +149,7 @@ public class ServiceEndpointServerImplTest extends TimedTesting {
 
         httpServer = new HttpServerMock();
         serviceServerImpl = new ServiceEndpointServerImpl(httpServer, encoder, protocolParser, serviceBundle,
-                mapper, 1, 100, 30, 10, null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
+                mapper, 1, 100, 30, 10, null, null, null, null, null, "localhost", 8080, 0, null, null, 50, 2, 2);
 
         callMeCounter = 0;
         responseCounter = 0;


### PR DESCRIPTION
Currently it's impossible to retrieve tags from service discovery or pass tags to an endpoint, this pull request allow to set tags then register them into service discovery provider. It also add host in Registration domain from Consul