### PR TITLE
Allow to retry to load services

### DIFF
--- a/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/impl/ServiceDiscoveryImpl.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/impl/ServiceDiscoveryImpl.java
@@ -249,7 +249,6 @@ public class ServiceDiscoveryImpl implements ServiceDiscovery {
     }
 
     public void loadServicesAsync(Callback<List<EndpointDefinition>> callback, final String serviceName) {
-
         final List<EndpointDefinition> endpointDefinitions = loadServices(serviceName);
         if (endpointDefinitions.size() > 0) {
             callback.accept(endpointDefinitions);
@@ -266,8 +265,16 @@ public class ServiceDiscoveryImpl implements ServiceDiscovery {
                 throw new IllegalStateException(e);
             }
             callbackMap.put(serviceName, callbacks);
+        } else {
+            try {
+                if (callbacks.size() == 0) {
+                    callbacks.put(callback);
+                    serviceNamesBeingLoaded.remove(serviceName);
+                }
+            } catch (InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
         }
-
     }
 
     @Override

--- a/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/impl/ServiceDiscoveryImpl.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/service/discovery/impl/ServiceDiscoveryImpl.java
@@ -252,6 +252,7 @@ public class ServiceDiscoveryImpl implements ServiceDiscovery {
         final List<EndpointDefinition> endpointDefinitions = loadServices(serviceName);
         if (endpointDefinitions.size() > 0) {
             callback.accept(endpointDefinitions);
+            return;
         }
 
         BlockingQueue<Callback<List<EndpointDefinition>>> callbacks


### PR DESCRIPTION
Currently it's not possible to gets notified when loading a service more than one time. 
This commit allow you to retry to load a services until its up (warning it needs synchronized code on client side).