### PR TITLE
Applied skeletal implementation to interface migration automated refactoring

### DIFF
--- a/qbit/admin/src/main/java/io/advantageous/qbit/metrics/StatReplicator.java
+++ b/qbit/admin/src/main/java/io/advantageous/qbit/metrics/StatReplicator.java
@@ -32,5 +32,7 @@ public interface StatReplicator extends RemoteTCPClientProxy, ServiceFlushable, 
 
     void replicateLevel(String name, long level, long time);
 
-    void replicateTiming(String name, long timing, long time);
+    default void replicateTiming(String name, long level, long time) {
+	
+	}
 }

--- a/qbit/admin/src/main/java/io/advantageous/qbit/metrics/support/NoOpReplicator.java
+++ b/qbit/admin/src/main/java/io/advantageous/qbit/metrics/support/NoOpReplicator.java
@@ -32,9 +32,4 @@ public class NoOpReplicator implements StatReplicator {
     @Override
     public final void replicateLevel(String name, long level, long now) {
     }
-
-    @Override
-    public void replicateTiming(String name, long level, long time) {
-
-    }
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/boon/client/BoonClientFactory.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/boon/client/BoonClientFactory.java
@@ -19,9 +19,6 @@
 package io.advantageous.qbit.boon.client;
 
 import io.advantageous.boon.core.Sys;
-import io.advantageous.qbit.client.BeforeMethodSent;
-import io.advantageous.qbit.client.Client;
-import io.advantageous.qbit.http.client.HttpClient;
 import io.advantageous.qbit.spi.ClientFactory;
 
 public class BoonClientFactory implements ClientFactory {
@@ -30,13 +27,4 @@ public class BoonClientFactory implements ClientFactory {
      * Holds on to Boon cache so we don't have to recreate reflected gak.
      */
     Object context = Sys.contextToHold();
-
-
-    @Override
-    public Client create(final String uri,
-                         final HttpClient httpClient,
-                         final int requestBatchSize,
-                         final BeforeMethodSent beforeMethodSent) {
-        return new BoonClient(uri, httpClient, requestBatchSize, beforeMethodSent);
-    }
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/boon/events/impl/BoonEventBusProxyCreator.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/boon/events/impl/BoonEventBusProxyCreator.java
@@ -50,12 +50,6 @@ public class BoonEventBusProxyCreator implements EventBusProxyCreator {
     Object context = Sys.contextToHold();
 
     @Override
-    public <T> T createProxy(final EventManager eventManager, final Class<T> eventBusProxyInterface) {
-
-        return createProxyWithChannelPrefix(eventManager, eventBusProxyInterface, null);
-    }
-
-    @Override
     public <T> T createProxyWithChannelPrefix(final EventManager eventManager, final Class<T> eventBusProxyInterface,
                                               final String channelPrefix) {
 

--- a/qbit/core/src/main/java/io/advantageous/qbit/boon/events/impl/BoonEventManager.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/boon/events/impl/BoonEventManager.java
@@ -21,7 +21,6 @@ package io.advantageous.qbit.boon.events.impl;
 import io.advantageous.boon.core.Str;
 import io.advantageous.boon.core.Sys;
 import io.advantageous.boon.core.reflection.AnnotationData;
-import io.advantageous.boon.core.reflection.BeanUtils;
 import io.advantageous.boon.core.reflection.ClassMeta;
 import io.advantageous.boon.core.reflection.MethodAccess;
 import io.advantageous.qbit.GlobalConstants;
@@ -47,7 +46,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static io.advantageous.boon.core.reflection.ClassMeta.classMeta;
 import static io.advantageous.qbit.annotation.AnnotationUtils.*;
-import static io.advantageous.qbit.service.ServiceContext.serviceContext;
 
 /**
  * @author rhightower
@@ -203,13 +201,6 @@ public class BoonEventManager implements EventManager {
 
 
         doListen(serviceQueue.service(), serviceQueue);
-    }
-
-
-    @Override
-    public void leave() {
-        final ServiceQueue serviceQueue = serviceContext().currentService();
-        leaveEventBus(serviceQueue);
     }
 
 
@@ -493,13 +484,6 @@ public class BoonEventManager implements EventManager {
         }
 
         return events;
-    }
-
-    @Override
-    public <T> void sendCopy(String channel, T event) {
-
-        T copy = BeanUtils.copy(event);
-        this.send(channel, copy);
     }
 
     @Override

--- a/qbit/core/src/main/java/io/advantageous/qbit/boon/service/impl/BoonServiceProxyFactory.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/boon/service/impl/BoonServiceProxyFactory.java
@@ -110,10 +110,4 @@ public class BoonServiceProxyFactory implements ServiceProxyFactory {
     }
 
 
-    @Override
-    public <T> T createProxy(Class<T> serviceInterface, String serviceName, EndPoint endPoint, BeforeMethodSent beforeMethodSent) {
-        return createProxyWithReturnAddress(serviceInterface, serviceName, "local", 0, new AtomicBoolean(true), "", endPoint, beforeMethodSent);
-    }
-
-
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/boon/spi/BoonProtocolParser.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/boon/spi/BoonProtocolParser.java
@@ -92,19 +92,6 @@ public class BoonProtocolParser implements ProtocolParser {
 
     }
 
-    @Override
-    public List<MethodCall<Object>> parseMethodCalls(String address, String body) {
-        //noinspection unchecked
-        return (List<MethodCall<Object>>) (Object) parse(address, body);
-    }
-
-    @Override
-    public List<Response<Object>> parseResponses(String address, String body) {
-        //noinspection unchecked
-        return (List<Response<Object>>) (Object) parse(address, body);
-    }
-
-
     private Response<Object> parseResponseFromChars(char[] args, final String returnAddress) {
         final char[][] chars = CharScanner.splitFromStartWithLimit(args, (char) PROTOCOL_SEPARATOR, 0, RESPONSE_RETURN);
 

--- a/qbit/core/src/main/java/io/advantageous/qbit/client/ServiceProxyFactory.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/client/ServiceProxyFactory.java
@@ -38,8 +38,10 @@ public interface ServiceProxyFactory {
                                        EndPoint serviceBundle,
                                        BeforeMethodSent beforeMethodSent);
 
-    <T> T createProxy(Class<T> serviceInterface,
+    default <T> T createProxy(Class<T> serviceInterface,
                       String serviceName,
-                      EndPoint serviceBundle,
-                      BeforeMethodSent beforeMethodSent);
+                      EndPoint endPoint,
+                      BeforeMethodSent beforeMethodSent) {
+	    return createProxyWithReturnAddress(serviceInterface, serviceName, "local", 0, new AtomicBoolean(true), "", endPoint, beforeMethodSent);
+	}
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/events/EventBusProxyCreator.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/events/EventBusProxyCreator.java
@@ -31,7 +31,10 @@ public interface EventBusProxyCreator {
         return createProxy(QBit.factory().systemEventManager(), eventBusProxyInterface);
     }
 
-    <T> T createProxy(final EventManager eventManager, final Class<T> eventBusProxyInterface);
+    default <T> T createProxy(final EventManager eventManager, final Class<T> eventBusProxyInterface) {
+	
+	    return createProxyWithChannelPrefix(eventManager, eventBusProxyInterface, null);
+	}
 
 
     <T> T createProxyWithChannelPrefix(final EventManager eventManager,

--- a/qbit/core/src/main/java/io/advantageous/qbit/events/EventManager.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/events/EventManager.java
@@ -18,6 +18,9 @@
 
 package io.advantageous.qbit.events;
 
+import static io.advantageous.qbit.service.ServiceContext.serviceContext;
+
+import io.advantageous.boon.core.reflection.BeanUtils;
 import io.advantageous.qbit.events.spi.EventTransferObject;
 import io.advantageous.qbit.service.ServiceQueue;
 
@@ -57,7 +60,10 @@ public interface EventManager {
     /**
      * Opposite of join. ONLY FOR SERVICES.
      */
-    void leave();
+    default void leave() {
+	    final ServiceQueue serviceQueue = serviceContext().currentService();
+	    leaveEventBus(serviceQueue);
+	}
 
     /**
      * This method can be called outside of a service.
@@ -131,7 +137,11 @@ public interface EventManager {
      * @param event   event
      * @param <T>     T
      */
-    <T> void sendCopy(String channel, T event);
+    default <T> void sendCopy(String channel, T event) {
+	
+	    T copy = BeanUtils.copy(event);
+	    this.send(channel, copy);
+	}
 
 
     void forwardEvent(EventTransferObject<Object> event);

--- a/qbit/core/src/main/java/io/advantageous/qbit/events/spi/EventTransferObject.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/events/spi/EventTransferObject.java
@@ -55,11 +55,6 @@ public class EventTransferObject<T> implements Event<T> {
     }
 
     @Override
-    public boolean isSingleton() {
-        return true;
-    }
-
-    @Override
     public String toString() {
         return "EventImpl{" +
                 "body=" + body +

--- a/qbit/core/src/main/java/io/advantageous/qbit/http/HttpTransport.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/http/HttpTransport.java
@@ -72,7 +72,9 @@ public interface HttpTransport extends Startable {
 
     void setHttpRequestsIdleConsumer(Consumer<Void> idleConsumer);
 
-    void setWebSocketIdleConsume(Consumer<Void> idleConsumer);
+    default void setWebSocketIdleConsume(Consumer<Void> idleConsumer) {
+	
+	}
 
     default HttpTransport startTransport() {
         start();

--- a/qbit/core/src/main/java/io/advantageous/qbit/http/request/HttpRequest.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/http/request/HttpRequest.java
@@ -114,16 +114,6 @@ public class HttpRequest implements Request<Object> {
     }
 
     @Override
-    public boolean hasParams() {
-        return false;
-    }
-
-    @Override
-    public boolean hasHeaders() {
-        return false;
-    }
-
-    @Override
     public long timestamp() {
         return timestamp;
     }

--- a/qbit/core/src/main/java/io/advantageous/qbit/http/server/websocket/WebSocketMessage.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/http/server/websocket/WebSocketMessage.java
@@ -91,16 +91,6 @@ public class WebSocketMessage implements Request<Object>, Cloneable {
     }
 
     @Override
-    public boolean hasParams() {
-        return false;
-    }
-
-    @Override
-    public boolean hasHeaders() {
-        return false;
-    }
-
-    @Override
     public long timestamp() {
         return timestamp;
     }
@@ -123,11 +113,6 @@ public class WebSocketMessage implements Request<Object>, Cloneable {
     @Override
     public Object body() {
         return message;
-    }
-
-    @Override
-    public boolean isSingleton() {
-        return true;
     }
 
     public String getUri() {

--- a/qbit/core/src/main/java/io/advantageous/qbit/message/Message.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/message/Message.java
@@ -33,7 +33,9 @@ public interface Message<T> {
 
     T body(); //Body could be a Map for parameters for forms or JSON or bytes[] or String
 
-    boolean isSingleton();
+    default boolean isSingleton() {
+	    return true;
+	}
 
 
     default MultiMap<String, String> params() {

--- a/qbit/core/src/main/java/io/advantageous/qbit/message/MethodCall.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/message/MethodCall.java
@@ -33,7 +33,9 @@ public interface MethodCall<T> extends Request<T> {
 
     long timestamp();
 
-    String objectName();
+    default String objectName() {
+	    return "";
+	}
 
     boolean hasCallback();
 

--- a/qbit/core/src/main/java/io/advantageous/qbit/message/Request.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/message/Request.java
@@ -37,15 +37,23 @@ public interface Request<T> extends Message<T> {
     }
 
 
-    boolean hasParams();
+    default boolean hasParams() {
+	    return false;
+	}
 
-    boolean hasHeaders();
+    default boolean hasHeaders() {
+	    return false;
+	}
 
     long timestamp();
 
-    boolean isHandled();
+    default boolean isHandled() {
+	    return false;
+	}
 
-    void handled();
+    default void handled() {
+	
+	}
 
     default boolean hasCallback() {
         return false;

--- a/qbit/core/src/main/java/io/advantageous/qbit/message/impl/MethodCallImpl.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/message/impl/MethodCallImpl.java
@@ -94,16 +94,6 @@ public class MethodCallImpl implements MethodCall<Object> {
     }
 
     @Override
-    public boolean isHandled() {
-        return false;
-    }
-
-    @Override
-    public void handled() {
-
-    }
-
-    @Override
     public String objectName() {
         return objectName;
     }
@@ -152,11 +142,6 @@ public class MethodCallImpl implements MethodCall<Object> {
 
     public void originatingRequest(Request<Object> originatingRequest) {
         this.originatingRequest = originatingRequest;
-    }
-
-    @Override
-    public boolean isSingleton() {
-        return true;
     }
 
     public boolean hasParams() {

--- a/qbit/core/src/main/java/io/advantageous/qbit/message/impl/MethodCallLocal.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/message/impl/MethodCallLocal.java
@@ -86,32 +86,8 @@ public class MethodCallLocal implements MethodCall<Object> {
     }
 
     @Override
-    public boolean hasParams() {
-        return false;
-    }
-
-    @Override
-    public boolean hasHeaders() {
-        return false;
-    }
-
-    @Override
     public long timestamp() {
         return timestamp;
-    }
-
-    @Override
-    public boolean isHandled() {
-        return false;
-    }
-
-    @Override
-    public void handled() {
-    }
-
-    @Override
-    public String objectName() {
-        return "";
     }
 
     @Override
@@ -127,10 +103,5 @@ public class MethodCallLocal implements MethodCall<Object> {
     @Override
     public Object body() {
         return arguments;
-    }
-
-    @Override
-    public boolean isSingleton() {
-        return true;
     }
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/message/impl/ResponseImpl.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/message/impl/ResponseImpl.java
@@ -132,11 +132,6 @@ public class ResponseImpl<T> implements Response<T> {
     }
 
     @Override
-    public boolean isSingleton() {
-        return true;
-    }
-
-    @Override
     public boolean wasErrors() {
         return errors;
     }

--- a/qbit/core/src/main/java/io/advantageous/qbit/meta/transformer/RequestTransformer.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/meta/transformer/RequestTransformer.java
@@ -18,6 +18,7 @@
 package io.advantageous.qbit.meta.transformer;
 
 import io.advantageous.qbit.http.request.HttpRequest;
+import io.advantageous.qbit.http.request.HttpRequestBuilder;
 import io.advantageous.qbit.message.MethodCall;
 
 import java.util.List;
@@ -27,12 +28,19 @@ import java.util.List;
  */
 public interface RequestTransformer {
 
-    MethodCall<Object> transform(HttpRequest request, List<String> errorsList);
+    default MethodCall<Object> transform(HttpRequest request, List<String> errorsList) {
+	
+	    return transformByPosition(request, errorsList, false);
+	}
 
     MethodCall<Object> transformByPosition(final HttpRequest request,
                                            final List<String> errorsList, boolean byPosition);
 
 
-    MethodCall<Object> transFormBridgeBody(Object body, List<String> errors, String address, String method);
+    default MethodCall<Object> transFormBridgeBody(Object body, List<String> errors, String address, String method) {
+	    final String uri = ("/" + address + "/" + method).replace("//", "/");
+	    final HttpRequest request = HttpRequestBuilder.httpRequestBuilder().setUri(uri).setBody(body == null ? null : body.toString()).setMethod("BRIDGE").build();
+	    return this.transformByPosition(request, errors, true);
+	}
 
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/meta/transformer/StandardRequestTransformer.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/meta/transformer/StandardRequestTransformer.java
@@ -26,7 +26,6 @@ import io.advantageous.qbit.Factory;
 import io.advantageous.qbit.QBit;
 import io.advantageous.qbit.annotation.RequestMethod;
 import io.advantageous.qbit.http.request.HttpRequest;
-import io.advantageous.qbit.http.request.HttpRequestBuilder;
 import io.advantageous.qbit.json.JsonMapper;
 import io.advantageous.qbit.message.MethodCall;
 import io.advantageous.qbit.message.MethodCallBuilder;
@@ -86,14 +85,6 @@ public class StandardRequestTransformer implements RequestTransformer {
         } catch (UnsupportedEncodingException e) {
             return value;
         }
-    }
-
-
-    @Override
-    public MethodCall<Object> transform(final HttpRequest request,
-                                        final List<String> errorsList) {
-
-        return transformByPosition(request, errorsList, false);
     }
 
 
@@ -327,13 +318,6 @@ public class StandardRequestTransformer implements RequestTransformer {
 
         return methodCallBuilder.build();
 
-    }
-
-    @Override
-    public MethodCall<Object> transFormBridgeBody(Object body, List<String> errors, String address, String method) {
-        final String uri = ("/" + address + "/" + method).replace("//", "/");
-        final HttpRequest request = HttpRequestBuilder.httpRequestBuilder().setUri(uri).setBody(body == null ? null : body.toString()).setMethod("BRIDGE").build();
-        return this.transformByPosition(request, errors, true);
     }
 
     private void handleMehtodTransformError(List<String> errorsList, MethodCallBuilder methodCallBuilder, Exception exception) {

--- a/qbit/core/src/main/java/io/advantageous/qbit/network/NetSocket.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/network/NetSocket.java
@@ -82,7 +82,11 @@ public interface NetSocket {
 
     void openAndWait();
 
-    void openAndNotify(final Consumer<NetSocket> openConsumer, Consumer<Exception> exceptionConsumer);
+    default void openAndNotify(final Consumer<NetSocket> openConsumer, Consumer<Exception> exceptionConsumer) {
+	
+	    this.setOpenConsumer(aVoid -> openConsumer.accept(this));
+	    open(exceptionConsumer);
+	}
 
 
     default void openAndNotify(final Consumer<NetSocket> openConsumer) {

--- a/qbit/core/src/main/java/io/advantageous/qbit/network/impl/NetSocketBase.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/network/impl/NetSocketBase.java
@@ -185,13 +185,6 @@ public class NetSocketBase implements NetSocket {
 
 
     @Override
-    public void openAndNotify(Consumer<NetSocket> openConsumer, Consumer<Exception> exceptionConsumer) {
-
-        this.setOpenConsumer(aVoid -> openConsumer.accept(this));
-        open(exceptionConsumer);
-    }
-
-    @Override
     public void openAndWait() {
 
         open(e -> {

--- a/qbit/core/src/main/java/io/advantageous/qbit/service/impl/CallbackManager.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/service/impl/CallbackManager.java
@@ -7,7 +7,11 @@ import io.advantageous.qbit.queue.Queue;
 public interface CallbackManager {
     void registerCallbacks(MethodCall<Object> methodCall);
 
-    void startReturnHandlerProcessor(Queue<Response<Object>> responseQueue);
+    default void startReturnHandlerProcessor(Queue<Response<Object>> responseQueue) {
+	
+	    //noinspection Convert2MethodRef
+	    responseQueue.startListener(response -> handleResponse(response));
+	}
 
     void handleResponse(Response<Object> response);
 

--- a/qbit/core/src/main/java/io/advantageous/qbit/service/impl/CallbackManagerWithTimeout.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/service/impl/CallbackManagerWithTimeout.java
@@ -20,7 +20,6 @@ package io.advantageous.qbit.service.impl;
 
 import io.advantageous.qbit.message.MethodCall;
 import io.advantageous.qbit.message.Response;
-import io.advantageous.qbit.queue.Queue;
 import io.advantageous.qbit.reactive.Callback;
 import io.advantageous.qbit.util.Timer;
 import org.slf4j.Logger;
@@ -92,18 +91,6 @@ public class CallbackManagerWithTimeout implements CallbackManager {
         registerHandlerCallbackForClient(methodCall, methodCall.callback());
     }
 
-
-    /**
-     * Handles responses coming back from services.
-     *
-     * @param responseQueue response queue
-     */
-    @Override
-    public void startReturnHandlerProcessor(final Queue<Response<Object>> responseQueue) {
-
-        //noinspection Convert2MethodRef
-        responseQueue.startListener(response -> handleResponse(response));
-    }
 
     @Override
     public void handleResponse(final Response<Object> response) {

--- a/qbit/core/src/main/java/io/advantageous/qbit/spi/ClientFactory.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/spi/ClientFactory.java
@@ -18,6 +18,7 @@
 
 package io.advantageous.qbit.spi;
 
+import io.advantageous.qbit.boon.client.BoonClient;
 import io.advantageous.qbit.client.BeforeMethodSent;
 import io.advantageous.qbit.client.Client;
 import io.advantageous.qbit.http.client.HttpClient;
@@ -31,8 +32,10 @@ import io.advantageous.qbit.http.client.HttpClient;
  */
 public interface ClientFactory {
 
-    Client create(String uri,
+    default Client create(String uri,
                   HttpClient httpClient,
                   int requestBatchSize,
-                  final BeforeMethodSent beforeMethodSent);
+                  final BeforeMethodSent beforeMethodSent) {
+	    return new BoonClient(uri, httpClient, requestBatchSize, beforeMethodSent);
+	}
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/spi/HttpClientFactory.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/spi/HttpClientFactory.java
@@ -19,6 +19,7 @@
 package io.advantageous.qbit.spi;
 
 import io.advantageous.qbit.http.client.HttpClient;
+import io.advantageous.qbit.vertx.http.client.HttpVertxClient;
 
 import java.util.function.Consumer;
 
@@ -26,7 +27,7 @@ import java.util.function.Consumer;
  * created by rhightower on 11/13/14.
  */
 public interface HttpClientFactory {
-    HttpClient create(String host, int port,
+    default HttpClient create(String host, int port,
                       int timeOutInMilliseconds, int poolSize,
                       boolean autoFlush, int flushRate,
                       boolean keepAlive, boolean pipeLine, boolean ssl,
@@ -38,5 +39,9 @@ public interface HttpClientFactory {
                       String trustStorePassword,
                       boolean tcpNoDelay,
                       int soLinger,
-                      Consumer<Throwable> errorHandler);
+                      Consumer<Throwable> errorHandler) {
+	    return new HttpVertxClient(host, port, timeOutInMilliseconds, poolSize, autoFlush,
+	            flushRate, keepAlive, pipeLine, ssl, verifyHost, trustAll, maxWebSocketFrameSize,
+	            tryUseCompression, trustStorePath, trustStorePassword, tcpNoDelay, soLinger, errorHandler);
+	}
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/spi/HttpServerFactory.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/spi/HttpServerFactory.java
@@ -26,6 +26,8 @@ import io.advantageous.qbit.http.server.RequestContinuePredicate;
 import io.advantageous.qbit.service.discovery.ServiceDiscovery;
 import io.advantageous.qbit.service.health.HealthServiceAsync;
 import io.advantageous.qbit.system.QBitSystemManager;
+import io.advantageous.qbit.vertx.http.server.HttpServerVertx;
+import io.vertx.core.Vertx;
 
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +38,7 @@ import java.util.concurrent.TimeUnit;
  */
 public interface HttpServerFactory {
 
-    HttpServer create(
+    default HttpServer create(
             HttpServerOptions options,
             String endPointName,
             QBitSystemManager systemManager,
@@ -45,5 +47,12 @@ public interface HttpServerFactory {
             final int serviceDiscoveryTtl,
             final TimeUnit serviceDiscoveryTtlTimeUnit,
             final CopyOnWriteArrayList<HttpResponseDecorator> decorators,
-            final HttpResponseCreator httpResponseCreator, RequestContinuePredicate requestBodyContinuePredicate);
+            final HttpResponseCreator httpResponseCreator, RequestContinuePredicate requestBodyContinuePredicate) {
+	
+	
+	    return new HttpServerVertx(true, Vertx.vertx(), endPointName, options,
+	            systemManager, serviceDiscovery, healthServiceAsync,
+	            serviceDiscoveryTtl, serviceDiscoveryTtlTimeUnit, decorators, httpResponseCreator, requestBodyContinuePredicate);
+	
+	}
 }

--- a/qbit/core/src/main/java/io/advantageous/qbit/spi/ProtocolParser.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/spi/ProtocolParser.java
@@ -36,9 +36,15 @@ public interface ProtocolParser {
 
     List<Message<Object>> parse(String address, String body);
 
-    List<MethodCall<Object>> parseMethodCalls(String addressPrefix, String body);
+    default List<MethodCall<Object>> parseMethodCalls(String address, String body) {
+	    //noinspection unchecked
+	    return (List<MethodCall<Object>>) (Object) parse(address, body);
+	}
 
-    List<Response<Object>> parseResponses(String addressPrefix, String body);
+    default List<Response<Object>> parseResponses(String address, String body) {
+	    //noinspection unchecked
+	    return (List<Response<Object>>) (Object) parse(address, body);
+	}
 
 
 }

--- a/qbit/core/src/test/java/io/advantageous/qbit/service/rest/endpoint/tests/sim/HttpServerSimulator.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/service/rest/endpoint/tests/sim/HttpServerSimulator.java
@@ -197,11 +197,6 @@ public class HttpServerSimulator implements HttpServer {
     }
 
     @Override
-    public void setWebSocketIdleConsume(Consumer<Void> idleConsumer) {
-
-    }
-
-    @Override
     public void start() {
 
     }

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/client/HttpVertxClientFactory.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/client/HttpVertxClientFactory.java
@@ -1,32 +1,6 @@
 package io.advantageous.qbit.vertx.http.client;
 
-import io.advantageous.qbit.http.client.HttpClient;
 import io.advantageous.qbit.spi.HttpClientFactory;
 
-import java.util.function.Consumer;
-
 public class HttpVertxClientFactory implements HttpClientFactory {
-    @Override
-    public HttpClient create(String host,
-                             int port,
-                             int timeOutInMilliseconds,
-                             int poolSize,
-                             boolean autoFlush,
-                             int flushRate,
-                             boolean keepAlive,
-                             boolean pipeLine,
-                             boolean ssl,
-                             boolean verifyHost,
-                             boolean trustAll,
-                             int maxWebSocketFrameSize,
-                             boolean tryUseCompression,
-                             String trustStorePath,
-                             String trustStorePassword,
-                             boolean tcpNoDelay,
-                             int soLinger,
-                             Consumer<Throwable> errorHandler) {
-        return new HttpVertxClient(host, port, timeOutInMilliseconds, poolSize, autoFlush,
-                flushRate, keepAlive, pipeLine, ssl, verifyHost, trustAll, maxWebSocketFrameSize,
-                tryUseCompression, trustStorePath, trustStorePassword, tcpNoDelay, soLinger, errorHandler);
-    }
 }

--- a/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/HttpServerVertxFactory.java
+++ b/qbit/vertx/src/main/java/io/advantageous/qbit/vertx/http/server/HttpServerVertxFactory.java
@@ -18,42 +18,10 @@
 
 package io.advantageous.qbit.vertx.http.server;
 
-import io.advantageous.qbit.http.config.HttpServerOptions;
-import io.advantageous.qbit.http.request.HttpResponseCreator;
-import io.advantageous.qbit.http.request.decorator.HttpResponseDecorator;
-import io.advantageous.qbit.http.server.HttpServer;
-import io.advantageous.qbit.http.server.RequestContinuePredicate;
-import io.advantageous.qbit.service.discovery.ServiceDiscovery;
-import io.advantageous.qbit.service.health.HealthServiceAsync;
 import io.advantageous.qbit.spi.HttpServerFactory;
-import io.advantageous.qbit.system.QBitSystemManager;
-import io.vertx.core.Vertx;
-
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author rhightower on 1/26/15.
  */
 public class HttpServerVertxFactory implements HttpServerFactory {
-
-
-    @Override
-    public HttpServer create(final HttpServerOptions options,
-                             final String endPointName,
-                             final QBitSystemManager systemManager,
-                             final ServiceDiscovery serviceDiscovery,
-                             final HealthServiceAsync healthServiceAsync,
-                             final int serviceDiscoveryTtl,
-                             final TimeUnit serviceDiscoveryTtlTimeUnit,
-                             final CopyOnWriteArrayList<HttpResponseDecorator> decorators,
-                             final HttpResponseCreator httpResponseCreator,
-                             final RequestContinuePredicate requestBodyContinuePredicate) {
-
-
-        return new HttpServerVertx(true, Vertx.vertx(), endPointName, options,
-                systemManager, serviceDiscovery, healthServiceAsync,
-                serviceDiscoveryTtl, serviceDiscoveryTtlTimeUnit, decorators, httpResponseCreator, requestBodyContinuePredicate);
-
-    }
 }


### PR DESCRIPTION
This is a semantics-preserving refactoring that migrates existing method implementations in classes to the corresponding implemented interface methods as `default` methods. The tool **does not** add new code; it only rearranges *existing* code.

The current state of this code does not seem to compile as some of the migrated method implementations cross gradle module boundaries. Still, any feedback you can supply would be helpful. Also, please let us know if new module dependencies would be acceptable.

- We are evaluating a research prototype automated refactoring Eclipse plug-in called [Migrate Skeletal Implementation to Interface](https://github.com/khatchad/Migrate-Skeletal-Implementation-to-Interface-Refactoring). We have applied the tool to your project in the hopes of receiving feedback.
- The approach is very conservative. That may mean that not all changes that can be made were made. Please feel free to continue the refactoring manually if you wish.
- We only migrated methods declared in abstract classes with the hopes of such methods being suitable default methods in corresponding interfaces.
- The source code should be semantically equivalent to the original.

Thank you for your help in this evaluation! Any feedback you can provide would be very helpful. In particular, we are interested if each of the proposed changes are helpful or not.