### PR TITLE
Promise handle support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
  */
 
 ext {
-    projectVersion = '1.11.2'
+    projectVersion = '1.12.0'
     boonVersion = '0.6.6'
     boonGroup = "io.advantageous.boon"
     springFrameworkVersion = '4.2.5.RELEASE'

--- a/qbit/build.gradle
+++ b/qbit/build.gradle
@@ -132,7 +132,7 @@ project('core') {
         compile "$boonGroup:boon-reflekt:$boonVersion"
         compile "$boonGroup:boon-json:$boonVersion"
         compile 'org.reactivestreams:reactive-streams:1.0.0'
-        compile 'io.advantageous.reakt:reakt:2.8.17'
+        compile 'io.advantageous.reakt:reakt:3.1.0'
         testCompile project(':qbit:test-support')
         testCompile 'org.mockito:mockito-core:1.10.19'
     }

--- a/qbit/core/src/main/java/io/advantageous/qbit/boon/client/BoonClient.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/boon/client/BoonClient.java
@@ -37,6 +37,7 @@ import io.advantageous.qbit.reactive.Callback;
 import io.advantageous.qbit.sender.Sender;
 import io.advantageous.qbit.service.BeforeMethodCall;
 import io.advantageous.reakt.promise.Promise;
+import io.advantageous.reakt.promise.PromiseHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -352,7 +353,7 @@ public class BoonClient implements Client {
         Class<?> returnType = null;
         Class<?> compType = null;
 
-        if (method.returnType() == Promise.class) {
+        if (PromiseHandle.class.isAssignableFrom(method.returnType()) ) {
 
             Type t0 = method.method().getGenericReturnType();
             if (t0 instanceof ParameterizedType) {

--- a/qbit/core/src/main/java/io/advantageous/qbit/boon/service/impl/BoonInvocationHandlerForEndPoint.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/boon/service/impl/BoonInvocationHandlerForEndPoint.java
@@ -9,6 +9,7 @@ import io.advantageous.qbit.service.EndPoint;
 import io.advantageous.qbit.util.Timer;
 import io.advantageous.reakt.Callback;
 import io.advantageous.reakt.promise.Promise;
+import io.advantageous.reakt.promise.PromiseHandle;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -55,7 +56,7 @@ class BoonInvocationHandlerForEndPoint implements InvocationHandler {
 
 
         for (Method method : serviceInterface.getMethods()) {
-            promiseMap.put(method.getName(), method.getReturnType() == Promise.class);
+            promiseMap.put(method.getName(), PromiseHandle.class.isAssignableFrom(method.getReturnType()) );
             methodMetaMap.put(method.getName(), hasReaktCallback(method.getParameterTypes()));
         }
         timestamp = Timer.timer().now();

--- a/qbit/core/src/main/java/io/advantageous/qbit/boon/service/impl/BoonInvocationHandlerForSendQueue.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/boon/service/impl/BoonInvocationHandlerForSendQueue.java
@@ -8,6 +8,7 @@ import io.advantageous.qbit.reakt.Reakt;
 import io.advantageous.qbit.util.Timer;
 import io.advantageous.reakt.Callback;
 import io.advantageous.reakt.promise.Promise;
+import io.advantageous.reakt.promise.PromiseHandle;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -40,7 +41,7 @@ public class BoonInvocationHandlerForSendQueue implements InvocationHandler {
         };
 
         for (Method method : serviceInterface.getMethods()) {
-            promiseMap.put(method.getName(), method.getReturnType() == Promise.class);
+            promiseMap.put(method.getName(), PromiseHandle.class.isAssignableFrom(method.getReturnType()));
             methodMetaMap.put(method.getName(), hasReaktCallback(method.getParameterTypes()));
         }
         timestamp = Timer.timer().now();

--- a/qbit/core/src/main/java/io/advantageous/qbit/boon/service/impl/BoonServiceMethodCallHandler.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/boon/service/impl/BoonServiceMethodCallHandler.java
@@ -37,6 +37,7 @@ import io.advantageous.qbit.reactive.Callback;
 import io.advantageous.qbit.service.ServiceMethodHandler;
 import io.advantageous.qbit.service.impl.ServiceConstants;
 import io.advantageous.reakt.promise.Promise;
+import io.advantageous.reakt.promise.PromiseHandle;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
@@ -137,7 +138,7 @@ public class BoonServiceMethodCallHandler implements ServiceMethodHandler {
 
     private boolean hasHandlers(MethodAccess serviceMethod) {
 
-        if (serviceMethod.returnType() == Promise.class) {
+        if (PromiseHandle.class.isAssignableFrom(serviceMethod.returnType())) {
             return true;
         }
 

--- a/qbit/core/src/main/java/io/advantageous/qbit/boon/service/impl/MapAndInvokeDynamic.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/boon/service/impl/MapAndInvokeDynamic.java
@@ -7,6 +7,7 @@ import io.advantageous.qbit.message.impl.ResponseImpl;
 import io.advantageous.qbit.reactive.Callback;
 import io.advantageous.qbit.service.impl.ServiceConstants;
 import io.advantageous.reakt.promise.Promise;
+import io.advantageous.reakt.promise.PromiseHandle;
 
 import java.util.List;
 
@@ -23,7 +24,7 @@ class MapAndInvokeDynamic implements MapAndInvoke {
     public Response<Object> mapArgsAsyncHandlersAndInvoke(MethodCall<Object> serviceMethodCall, MethodAccess serviceMethod) {
 
 
-        if (serviceMethod.parameterTypes().length == 0 && !(serviceMethod.returnType() == Promise.class)) {
+        if (serviceMethod.parameterTypes().length == 0 && !(PromiseHandle.class.isAssignableFrom(serviceMethod.returnType()))) {
 
             Object returnValue = serviceMethod.invokeDynamicObject(boonServiceMethodCallHandler.service, null);
             return boonServiceMethodCallHandler.response(serviceMethod, serviceMethodCall, returnValue);

--- a/qbit/core/src/main/java/io/advantageous/qbit/service/impl/BaseServiceQueueImpl.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/service/impl/BaseServiceQueueImpl.java
@@ -65,6 +65,7 @@ import io.advantageous.qbit.transforms.NoOpResponseTransformer;
 import io.advantageous.qbit.transforms.Transformer;
 import io.advantageous.qbit.util.Timer;
 import io.advantageous.reakt.promise.Promise;
+import io.advantageous.reakt.promise.PromiseHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -699,7 +700,7 @@ public class BaseServiceQueueImpl implements ServiceQueue {
         final Method[] declaredMethods = classMeta.cls().getDeclaredMethods();
 
         for (Method m : declaredMethods) {
-            if (!(m.getReturnType() == void.class || m.getReturnType() == Promise.class)) {
+            if (!(m.getReturnType() == void.class || PromiseHandle.class.isAssignableFrom(m.getReturnType()))) {
                 throw new IllegalStateException("Async interface can only return void or a Promise " + serviceInterface.getName());
             }
         }

--- a/qbit/core/src/test/java/io/advantageous/qbit/service/rest/endpoint/tests/services/EmployeeServiceCollectionTestService.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/service/rest/endpoint/tests/services/EmployeeServiceCollectionTestService.java
@@ -10,6 +10,7 @@ import io.advantageous.qbit.annotation.Service;
 import io.advantageous.qbit.reactive.Callback;
 import io.advantageous.qbit.service.rest.endpoint.tests.model.Employee;
 import io.advantageous.reakt.promise.Promise;
+import io.advantageous.reakt.promise.PromiseHandle;
 import io.advantageous.reakt.promise.Promises;
 
 import java.util.List;
@@ -158,6 +159,11 @@ public class EmployeeServiceCollectionTestService {
     @RequestMapping("/returnMapByPromise")
     public Promise<Map<String, Employee>> returnMapByPromise() {
         return Promises.invokablePromise(promise -> promise.resolve(Maps.map("1", new Employee(1, "Rick"), "2", new Employee(2, "Diana"))));
+    }
+
+    @RequestMapping("/returnMapByPromiseHandle")
+    public PromiseHandle<Map<String, Employee>> returnMapByPromiseHandle() {
+        return Promises.deferCall(promise -> promise.resolve(Maps.map("1", new Employee(1, "Rick"), "2", new Employee(2, "Diana"))));
     }
 
 }

--- a/qbit/core/src/test/java/io/advantageous/qbit/service/rest/endpoint/tests/tests/CollectionArrayUserDefinedObjectRESTTest.java
+++ b/qbit/core/src/test/java/io/advantageous/qbit/service/rest/endpoint/tests/tests/CollectionArrayUserDefinedObjectRESTTest.java
@@ -210,6 +210,21 @@ public class CollectionArrayUserDefinedObjectRESTTest {
 
     }
 
+    @Test
+    public void testReturnMapByPromiseHandle() {
+
+        final HttpTextResponse httpResponse = httpServerSimulator.get("/es/returnMapByPromiseHandle");
+
+        assertEquals(200, httpResponse.code());
+
+        Map<String, Employee> employeeMap = new BoonJsonMapper().fromJsonMap(httpResponse.body(), String.class, Employee.class);
+
+        assertEquals(2, employeeMap.size());
+
+        System.out.println(employeeMap);
+
+    }
+
 
     @Test
     public void testSendEmployeesWithCallback() {

--- a/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/PerfTestHello.java
+++ b/qbit/vertx/src/test/java/io/advantageous/qbit/vertx/PerfTestHello.java
@@ -1,0 +1,26 @@
+package io.advantageous.qbit.vertx;
+
+import io.advantageous.qbit.annotation.RequestMapping;
+import io.advantageous.qbit.annotation.http.GET;
+import io.advantageous.qbit.server.EndpointServerBuilder;
+
+@RequestMapping("/")
+public class PerfTestHello {
+
+
+    @GET
+    public String hello() {
+        return "hello";
+    }
+
+    public static void main(final String... args) {
+        final EndpointServerBuilder endpointServerBuilder = EndpointServerBuilder.endpointServerBuilder();
+        endpointServerBuilder.getRequestQueueBuilder().setBatchSize(1);
+        endpointServerBuilder.getResponseQueueBuilder().setBatchSize(1);
+
+        endpointServerBuilder.setFlushResponseInterval(10)
+                .setUri("/").setPort(9666)
+                .addService(new PerfTestHello()).build().startServer();
+
+    }
+}


### PR DESCRIPTION
https://github.com/advantageous/qbit/issues/763

https://github.com/advantageous/reakt/issues/52

https://github.com/advantageous/reakt/pull/53

```java

    interface ServiceDiscovery {
        PromiseHandle<URI> lookupServiceByPromiseHandle(final URI uri);
    }
```

A `promiseHandle` does not have as many methods it only has `then*`, `catch*`, `invoke`, and `blockingGet`. 

#### Usage
```java

    public class ServiceDiscoveryImpl {

        public PromiseHandle<URI> lookupServiceByPromiseHandle(final URI uri) {
            return Promises.deferCall(callback -> {
                    if (uri == null) {
                        callback.reject("uri can't be null");
                    } else {
                        callback.resolve(successResult);
                    }
                });
        }
```

Instead of `invokeablePromise` from `Promises`, you use `Promises.deferCall` which returns a `PromiseHandle` and takes a `Consumer<CallbackHandle>`.

`Promises.deferCall` is preferred. 

#### CallbackHandle 
```java
package io.advantageous.reakt;



/**
 * Simplified interface to a callback, hiding a callbacks hierarchy and dual roles.
 * This is the service view of a callback.
 * This focuses on just resolution methods of a callback.
 */
public interface CallbackHandle<T> {

    /**
     * (Service view)
     * This allows services to send back a failed result easily to the client/handler.
     * <p>
     * This is a helper methods for producers (services that produce results) to send a failed result.
     *
     * @param error error
     */
    void reject(final Throwable error) ;


    /**
     * (Service view)
     * This allows services to send back a failed result easily to the client/handler.
     * <p>
     * This is a helper methods for producers (services that produce results) to send a failed result.
     *
     * @param errorMessage error message
     */
    void reject(final String errorMessage);


    /**
     * (Service view)
     * This allows services to send back a failed result easily to the client/handler.
     * <p>
     * This is a helper methods for producers (services that produce results) to send a failed result.
     *
     * @param errorMessage error message
     * @param error        exception
     */
    void reject(final String errorMessage, final Throwable error) ;



    /**
     * Calls replayDone, for VOID callback only. ES6 promise style.
     */
    void resolve();

    /**
     * Resolve resolves a promise.
     *
     * @param result makes it more compatible with ES6 style promises
     */
    void resolve(final T result);


}

```

A `CallbackHandle` has five methods for resolution.

#### PromiseHandle
```java
package io.advantageous.reakt.promise;

import io.advantageous.reakt.Expected;

import java.time.Duration;
import java.util.function.Consumer;

/**
 * Simplified interface to promise that hides the complexity and hierarchy of a Promise.
 */
public interface PromiseHandle<T> {


    /**
     * If a result is sent, and there was no error, then handle the result.
     * <p>
     * There is only one {@code then} Handler.
     * </p>
     * Unlike ES6, {@code then(..)} cannot be chained per se, but {@code whenComplete(..)}, and
     * {@code }thenMap(...)} can be nested.
     *
     * @param consumer executed if result has no error.
     * @return this, fluent API
     * @throws NullPointerException if result is present and {@code consumer} is null
     */
    PromiseHandle<T> then(Consumer<T> consumer);

    /**
     * If a result is sent, and there was no error, then handle the result as a value which could be null.
     * <p>
     * There is only one thenExpect handler per promise.
     * <p>
     * Unlike ES6, {@code thenExpect(..)} cannot be chained per se as it does not create a new promise,
     * but {@code whenComplete(..)}, and {@code }thenMap(...)} can be chained.
     * <p>
     * This does not create a new promise.
     *
     * @param consumer executed if result has no error.
     * @return this, fluent API
     * @throws NullPointerException if result is present and {@code consumer} is
     *                              null
     */
    PromiseHandle<T> thenExpect(Consumer<Expected<T>> consumer);

    /**
     * If a result is sent, and there is an error, then handle handle the error.
     *
     * @param consumer executed if result has error.
     * @return this, fluent API
     * @throws NullPointerException if result is present and {@code consumer} is null
     */
    PromiseHandle<T> catchError(Consumer<Throwable> consumer);


    /**
     * Allows promises returned from, for example, proxy stubs for services methods to invoke the operation.
     * <p>
     * This allows use to set up the catchError and then before the method is async invoked.
     * <p>
     * Example Remote Proxy Gen to support returning Reakt invokeable promise
     * <pre>
     * <code>
     *     employeeService.lookupEmployee("123")
     *           .then((employee)-&gt; {...})
     *           .catchError(...)
     *           .invoke();
     * </code>
     * </pre>
     *
     * @return this, fluent
     */
    PromiseHandle<T> invoke();

    /**
     * If the thenSafeExpect handler throws an exception, this will report it as if it it was caught by catchError.
     * <p>
     * This is convenient if you are running your handler with an async lib that is not reporting or catching
     * exceptions as your code is running on their threads.
     * <p>
     * If a result is sent, and there was no error, then handle the result as a value which could be null.
     * <p>
     * There is only one thenSafeExpect or thenExpect handler per promise.
     * Once then is called all other then* handlers are safe.
     * <p>
     * Unlike ES6, {@code thenExpect(..)} cannot be chained per se as it does not create a new promise,
     * but {@code whenComplete(..)}, and {@code }thenMap(...)} can be chained.
     * <p>
     * This does not create a new promise.
     *
     * @param consumer executed if result has no error.
     * @return this, fluent API
     * @throws NullPointerException if result is present and {@code consumer} is
     *                              null
     */
    PromiseHandle<T> thenSafeExpect(Consumer<Expected<T>> consumer);


    /**
     * If the {@code then} handler throws an exception, this will report the exception as if it were caught
     * by {@code catchError}.
     * <p>
     * This is convenient if you are running your handler with an async lib that is not reporting or catching
     * exceptions as your code is running on their threads.
     * <p>
     * If a result is sent, and there was no error, then handle the result as a value which could be null.
     * <p>
     * There is only one thenSafe or then handler per promise.
     * Once then is called all other then* handlers are safe.
     * <p>
     * Unlike ES6, {@code thenExpect(..)} cannot be chained per se as it does not create a new promise,
     * but {@code whenComplete(..)}, and {@code }thenMap(...)} can be chained.
     * <p>
     * This does not create a new promise.
     *
     * @param consumer executed if result has no error.
     * @return this, fluent API
     * @throws NullPointerException if result is present and {@code consumer} is
     *                              null
     */
    PromiseHandle<T> thenSafe(Consumer<T> consumer);


    /**
     * Used for testing and legacy integration.
     * This turns an async promise into a blocking promise and then does a get operations.
     * @param duration duration to wait for call
     * @return result of call, blocks until return comes back.
     */
    T blockingGet(Duration duration);

    /**
     * Used for testing and legacy integration.
     * This turns an async promise into a blocking promise and then does a get operations.
     * @return result of call, blocks until return comes back.
     */
    T blockingGet();

    /**
     * If backed by a Promise then this will return that promise, otherwise throws an IllegalStateException.
     * @return promise that backs this handle
     */
    default Promise<T> asPromise() {
        return (Promise<T>) this;
    }

}

```
