### PR TITLE
Not to lose SoftenedException with just a message

### DIFF
--- a/qbit/core/src/main/java/io/advantageous/qbit/message/impl/ResponseImpl.java
+++ b/qbit/core/src/main/java/io/advantageous/qbit/message/impl/ResponseImpl.java
@@ -64,7 +64,7 @@ public class ResponseImpl<T> implements Response<T> {
         this.timestamp = methodCall.timestamp();
         this.id = methodCall.id();
 
-        if (ex instanceof Exceptions.SoftenedException) {
+        if (ex instanceof Exceptions.SoftenedException && ex.getCause() != null) {
             this.body = ex.getCause();
         } else {
             this.body = ex;


### PR DESCRIPTION
`Exceptions.SoftenedException` has a constructor that does not take `cause` therefore in this case we won't know anything about the error that's just happened. The special treatment for `SoftenedException` needs to be ignored if the `cause` is not set.